### PR TITLE
Don't unwrap on checking for extension

### DIFF
--- a/roslibrust_rospack/src/lib.rs
+++ b/roslibrust_rospack/src/lib.rs
@@ -116,10 +116,12 @@ fn message_files_from_path(path: &Path, ext: &str) -> io::Result<Vec<PathBuf>> {
                     message_files_from_path(entry.path().as_path(), ext)?,
                 ]
                 .concat()
-            } else if entry.path().as_path().is_file()
-                && entry.path().extension().unwrap().to_str().unwrap() == ext
-            {
-                msg_files.push(entry.path())
+            } else if entry.path().as_path().is_file() {
+                if let Some(extension) = entry.path().extension() {
+                    if extension.to_str().unwrap() == ext {
+                        msg_files.push(entry.path())
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
This was a pretty dumb oversight, but many files don't have an extension and will return `None`. I've updated the parsing to account for this.