### PR TITLE
Generate md5sum

### DIFF
--- a/.github/workflows/noetic.yml
+++ b/.github/workflows/noetic.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   HOME: /root
+  ROS_PACKAGE_PATH: /opt/ros/noetic/share
 
 jobs:
   noetic:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
  - Bug causing single quoted string constants in message files to not be parsed correctly
  - Bug causing float constants in message files to cause compiler errors because `f32 = 0;` is not allowed in rust
+ - Bug where packages were not properly de-duplicated during discovery.
 
 ## 0.6.0 - December 12, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Added public APIs for getting message data from search and for generating Rust code given message data in roslibrust_codegen
  - More useful logs available when running codegen
  - Refactor some of the public APIs and types in roslibrust_codegen (concept of `ParsedMessageFile` vs `MessageFile`)
+ - Added a method `get_md5sum` to `MessageFile`
 
 ### Fixed
  - Bug causing single quoted string constants in message files to not be parsed correctly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - More useful logs available when running codegen
  - Refactor some of the public APIs and types in roslibrust_codegen (concept of `ParsedMessageFile` vs `MessageFile`)
  - Added a method `get_md5sum` to `MessageFile`
+ - Additional code generation API and macro which excludes `ROS_PACKAGE_PATH`
 
 ### Fixed
  - Bug causing single quoted string constants in message files to not be parsed correctly

--- a/roslibrust/examples/ros1_ros2_bridge_example.rs
+++ b/roslibrust/examples/ros1_ros2_bridge_example.rs
@@ -14,7 +14,7 @@ mod ros1 {
 }
 
 mod ros2 {
-    roslibrust_codegen_macro::find_and_generate_ros_messages!(
+    roslibrust_codegen_macro::find_and_generate_ros_messages_without_ros_package_path!(
         "assets/ros2_common_interfaces/std_msgs"
     );
 }

--- a/roslibrust/src/lib.rs
+++ b/roslibrust/src/lib.rs
@@ -33,12 +33,12 @@
 //!
 //! ## Message Generation
 //! Message generation is provided in two APIs. The first, which is visible in `roslibrust/examples`, is a proc-macro which can be invoked to generate ROS message structs in place:
-//! ```
+//! ```ignore
 //! use roslibrust_codegen_macro::find_and_generate_ros_messages;
 //! find_and_generate_ros_messages!();
 //! ```
 //! If you have ROS installed, this macro will search for message files under paths in the `ROS_PACKAGE_PATH`. If you do not have ROS installed in your environment, you can specify search paths explicitly:
-//! ```
+//! ```ignore
 //! use roslibrust_codegen_macro::find_and_generate_ros_messages;
 //! find_and_generate_ros_messages!("/path/to/noetic/packages", "/path/to/my/packages");
 //! ```

--- a/roslibrust_codegen/Cargo.toml
+++ b/roslibrust_codegen/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["science::robotics"]
 [dependencies]
 lazy_static = "1.4"
 log = "0.4"
+md5 = "0.7"
 proc-macro2 = "1.0"
 quote = "1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/roslibrust_codegen/Cargo.toml
+++ b/roslibrust_codegen/Cargo.toml
@@ -30,6 +30,10 @@ default = ["tokio"]
 all = ["tokio"]
 # Enables support for tokio time conversions
 tokio = [ "dep:tokio" ]
+# For use with CI environment or any environment with ROS1 installed
+ros1_test = []
+# For use with CI environment or any environment with ROS2 installed
+ros2_test = []
 # TODO do this!
 # # Enables support for chrono time conversions
 # chrono = []

--- a/roslibrust_codegen/src/gen.rs
+++ b/roslibrust_codegen/src/gen.rs
@@ -174,47 +174,6 @@ pub fn generate_mod(
     }
 }
 
-pub fn replace_ros_types_with_rust_types(mut msg: ParsedMessageFile) -> ParsedMessageFile {
-    //const INTERNAL_STD_MSGS: [&str; 1] = ["Header"];
-
-    // If we couldn't determine the package type, assume ROS1 for now
-    let pkg_version = msg.version.unwrap_or(RosVersion::ROS1);
-
-    msg.constants = msg
-        .constants
-        .into_iter()
-        .map(|mut constant| {
-            if let Some(rust_type) =
-                convert_ros_type_to_rust_type(pkg_version, constant.constant_type.as_str())
-            {
-                constant.constant_type = rust_type.to_owned();
-                // We do not need to consider the package for constants as they're required
-                // to be built-in types other than Time and Duration (I think Header is not
-                // technically built-in)
-            }
-            constant
-        })
-        .collect();
-    msg.fields = msg
-        .fields
-        .into_iter()
-        .map(|mut field| {
-            if let Some(rust_type) =
-                convert_ros_type_to_rust_type(pkg_version, field.field_type.field_type.as_str())
-            {
-                field.field_type.field_type = rust_type.to_owned();
-            }
-            // for std_msg in INTERNAL_STD_MSGS {
-            //     if field.field_type.field_type.as_str() == std_msg {
-            //         field.field_type.package_name = Some("std_msgs".into());
-            //     }
-            // }
-            field
-        })
-        .collect();
-    msg
-}
-
 fn ros_literal_to_rust_literal(ros_type: &str, literal: &RosLiteral, is_vec: bool) -> TokenStream {
     // TODO: The naming of all the functions under this tree seems inaccurate
     parse_ros_value(ros_type, &literal.inner, is_vec)

--- a/roslibrust_codegen/src/gen.rs
+++ b/roslibrust_codegen/src/gen.rs
@@ -5,8 +5,8 @@ use std::str::FromStr;
 use syn::parse_quote;
 
 use crate::parse::{
-    convert_ros_type_to_rust_type, ConstantInfo, FieldInfo,
-    ParsedMessageFile, ParsedServiceFile, RosLiteral,
+    convert_ros_type_to_rust_type, ConstantInfo, FieldInfo, ParsedMessageFile, ParsedServiceFile,
+    RosLiteral,
 };
 use crate::utils::RosVersion;
 

--- a/roslibrust_codegen/src/gen.rs
+++ b/roslibrust_codegen/src/gen.rs
@@ -46,7 +46,6 @@ pub fn generate_service(service: ParsedServiceFile) -> TokenStream {
 }
 
 pub fn generate_struct(msg: ParsedMessageFile) -> TokenStream {
-    //let msg = replace_ros_types_with_rust_types(msg);
     let attrs = derive_attrs();
     let fields = msg
         .fields

--- a/roslibrust_codegen/src/gen.rs
+++ b/roslibrust_codegen/src/gen.rs
@@ -1,13 +1,12 @@
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote, ToTokens};
 use serde::de::DeserializeOwned;
-use std::collections::HashMap;
 use std::str::FromStr;
 use syn::parse_quote;
 
 use crate::parse::{
-    ParsedMessageFile, ParsedServiceFile, RosLiteral, ROS_2_TYPE_TO_RUST_TYPE_MAP,
-    ROS_TYPE_TO_RUST_TYPE_MAP,
+    convert_ros_type_to_rust_type, ConstantInfo, FieldInfo,
+    ParsedMessageFile, ParsedServiceFile, RosLiteral,
 };
 use crate::utils::RosVersion;
 
@@ -52,44 +51,8 @@ pub fn generate_struct(msg: ParsedMessageFile) -> TokenStream {
     let fields = msg
         .fields
         .into_iter()
-        .map(|mut field| {
-            field.field_type.field_type = match field.field_type.package_name {
-                Some(ref pkg) => {
-                    if pkg.as_str() == msg.package.as_str() {
-                        format!("self::{}", field.field_type.field_type)
-                    } else {
-                        format!("{}::{}", pkg, field.field_type.field_type)
-                    }
-                }
-                None => field.field_type.field_type.clone(),
-            };
-            let field_type = if field.field_type.is_vec {
-                format!("::std::vec::Vec<{}>", field.field_type.field_type)
-            } else {
-                field.field_type.field_type.clone()
-            };
-            let field_type = TokenStream::from_str(field_type.as_str()).unwrap();
-
-            let field_name = format_ident!("r#{}", field.field_name);
-            if let Some(ref default_val) = field.default {
-                let default_val =
-                    ros_literal_to_rust_literal(&field.field_type.field_type, default_val, false);
-                if field.field_type.is_vec {
-                    // For vectors use smart_defaults "dynamic" style
-                    quote! {
-                        #[default(_code = #default_val)]
-                        pub #field_name: #field_type,
-                    }
-                } else {
-                    // For non vectors use smart_default's constant style
-                    quote! {
-                      #[default(#default_val)]
-                      pub #field_name: #field_type,
-                    }
-                }
-            } else {
-                quote! { pub #field_name: #field_type, }
-            }
+        .map(|field| {
+            generate_field_definition(field, &msg.package, msg.version.unwrap_or(RosVersion::ROS1))
         })
         .collect::<Vec<TokenStream>>();
 
@@ -97,18 +60,7 @@ pub fn generate_struct(msg: ParsedMessageFile) -> TokenStream {
         .constants
         .into_iter()
         .map(|constant| {
-            let constant_name = format_ident!("r#{}", constant.constant_name);
-            let constant_type = if constant.constant_type == "::std::string::String" {
-                String::from("&'static str")
-            } else {
-                // Oof it's ugly in here
-                constant.constant_type.clone()
-            };
-            let constant_type = TokenStream::from_str(constant_type.as_str()).unwrap();
-            let constant_value =
-                ros_literal_to_rust_literal(&constant.constant_type, &constant.constant_value, false);
-
-            quote! { pub const #constant_name: #constant_type = #constant_value; }
+            generate_constant_field_definition(constant, msg.version.unwrap_or(RosVersion::ROS1))
         })
         .collect::<Vec<TokenStream>>();
 
@@ -138,6 +90,68 @@ pub fn generate_struct(msg: ParsedMessageFile) -> TokenStream {
     base
 }
 
+fn generate_field_definition(field: FieldInfo, msg_pkg: &str, version: RosVersion) -> TokenStream {
+    let rust_field_type = match field.field_type.package_name {
+        Some(ref pkg) => {
+            if pkg.as_str() == msg_pkg {
+                format!("self::{}", field.field_type.field_type)
+            } else {
+                format!("{}::{}", pkg, field.field_type.field_type)
+            }
+        }
+        None => convert_ros_type_to_rust_type(version, &field.field_type.field_type)
+            .expect(&format!("No Rust type for {}", field.field_type))
+            .to_owned(),
+    };
+    let rust_field_type = if field.field_type.is_vec {
+        format!("::std::vec::Vec<{}>", rust_field_type)
+    } else {
+        rust_field_type
+    };
+    let rust_field_type = TokenStream::from_str(rust_field_type.as_str()).unwrap();
+
+    let field_name = format_ident!("r#{}", field.field_name);
+    if let Some(ref default_val) = field.default {
+        let default_val = ros_literal_to_rust_literal(
+            &field.field_type.field_type,
+            default_val,
+            field.field_type.is_vec,
+        );
+        if field.field_type.is_vec {
+            // For vectors use smart_defaults "dynamic" style
+            quote! {
+                #[default(_code = #default_val)]
+                pub #field_name: #rust_field_type,
+            }
+        } else {
+            // For non vectors use smart_default's constant style
+            quote! {
+              #[default(#default_val)]
+              pub #field_name: #rust_field_type,
+            }
+        }
+    } else {
+        quote! { pub #field_name: #rust_field_type, }
+    }
+}
+
+fn generate_constant_field_definition(constant: ConstantInfo, version: RosVersion) -> TokenStream {
+    let constant_name = format_ident!("r#{}", constant.constant_name);
+    let constant_rust_type =
+        convert_ros_type_to_rust_type(version, &constant.constant_type).unwrap();
+    let constant_rust_type = if constant_rust_type == "::std::string::String" {
+        String::from("&'static str")
+    } else {
+        // Oof it's ugly in here
+        constant_rust_type.to_owned()
+    };
+    let constant_rust_type = TokenStream::from_str(constant_rust_type.as_str()).unwrap();
+    let constant_value =
+        ros_literal_to_rust_literal(&constant.constant_type, &constant.constant_value, false);
+
+    quote! { pub const #constant_name: #constant_rust_type = #constant_value; }
+}
+
 pub fn generate_mod(
     pkg_name: String,
     struct_definitions: Vec<TokenStream>,
@@ -161,27 +175,19 @@ pub fn generate_mod(
 }
 
 pub fn replace_ros_types_with_rust_types(mut msg: ParsedMessageFile) -> ParsedMessageFile {
-    const INTERNAL_STD_MSGS: [&str; 1] = ["Header"];
+    //const INTERNAL_STD_MSGS: [&str; 1] = ["Header"];
 
-    // Select which type conversion map to use depending on ros version
-    let prop_map: &HashMap<&'static str, &'static str> = match msg.version {
-        Some(RosVersion::ROS1) => &ROS_TYPE_TO_RUST_TYPE_MAP,
-        Some(RosVersion::ROS2) => &ROS_2_TYPE_TO_RUST_TYPE_MAP,
-        None => {
-            // If we couldn't determine the package type, assume ROS1 for now
-            &ROS_TYPE_TO_RUST_TYPE_MAP
-        }
-    };
+    // If we couldn't determine the package type, assume ROS1 for now
+    let pkg_version = msg.version.unwrap_or(RosVersion::ROS1);
 
     msg.constants = msg
         .constants
         .into_iter()
         .map(|mut constant| {
-            if prop_map.contains_key(constant.constant_type.as_str()) {
-                constant.constant_type = prop_map
-                    .get(constant.constant_type.as_str())
-                    .unwrap()
-                    .to_string();
+            if let Some(rust_type) =
+                convert_ros_type_to_rust_type(pkg_version, constant.constant_type.as_str())
+            {
+                constant.constant_type = rust_type.to_owned();
                 // We do not need to consider the package for constants as they're required
                 // to be built-in types other than Time and Duration (I think Header is not
                 // technically built-in)
@@ -193,15 +199,16 @@ pub fn replace_ros_types_with_rust_types(mut msg: ParsedMessageFile) -> ParsedMe
         .fields
         .into_iter()
         .map(|mut field| {
-            field.field_type.field_type = prop_map
-                .get(field.field_type.field_type.as_str())
-                .unwrap_or(&field.field_type.field_type.as_str())
-                .to_string();
-            for std_msg in INTERNAL_STD_MSGS {
-                if field.field_type.field_type.as_str() == std_msg {
-                    field.field_type.package_name = Some("std_msgs".into());
-                }
+            if let Some(rust_type) =
+                convert_ros_type_to_rust_type(pkg_version, field.field_type.field_type.as_str())
+            {
+                field.field_type.field_type = rust_type.to_owned();
             }
+            // for std_msg in INTERNAL_STD_MSGS {
+            //     if field.field_type.field_type.as_str() == std_msg {
+            //         field.field_type.package_name = Some("std_msgs".into());
+            //     }
+            // }
             field
         })
         .collect();

--- a/roslibrust_codegen/src/integral_types.rs
+++ b/roslibrust_codegen/src/integral_types.rs
@@ -16,9 +16,9 @@ pub struct Time {
     pub nsecs: u32,
 }
 
-impl Into<Time> for std::time::SystemTime {
-    fn into(self) -> Time {
-        let delta = self
+impl From<std::time::SystemTime> for Time {
+    fn from(val: std::time::SystemTime) -> Self {
+        let delta = val
             .duration_since(std::time::UNIX_EPOCH)
             .expect("Failed to convert system time into unix epoch");
         let downcast_secs = u32::try_from(delta.as_secs()).expect("Failed to convert system time to ROS representation, seconds term overflows u32 likely");
@@ -44,11 +44,11 @@ pub struct Duration {
 }
 
 /// Note this provides both tokio::time::Duration and std::time::Duration
-impl Into<Duration> for tokio::time::Duration {
-    fn into(self) -> Duration {
-        let downcast_sec = i32::try_from(self.as_secs())
+impl From<tokio::time::Duration> for Duration {
+    fn from(val: tokio::time::Duration) -> Self {
+        let downcast_sec = i32::try_from(val.as_secs())
             .expect("Failed to cast tokio duration to ROS duration, secs could not fit in i32");
-        let downcast_nsec = i32::try_from(self.subsec_nanos())
+        let downcast_nsec = i32::try_from(val.subsec_nanos())
             .expect("Failed to cast tokio duration ROS duration, nsecs could not fit in i32");
         Duration {
             sec: downcast_sec,

--- a/roslibrust_codegen/src/lib.rs
+++ b/roslibrust_codegen/src/lib.rs
@@ -56,10 +56,7 @@ impl MessageFile {
         graph: &BTreeMap<String, MessageFile>,
     ) -> Option<Self> {
         let md5sum = Self::compute_md5sum(&parsed, graph)?;
-        Some(MessageFile {
-            parsed,
-            md5sum,
-        })
+        Some(MessageFile { parsed, md5sum })
     }
 
     pub fn get_full_name(&self) -> String {
@@ -84,10 +81,7 @@ impl MessageFile {
         for field in &parsed.fields {
             let field_type = field.field_type.field_type.as_str();
             if is_intrinsic_type(parsed.version.unwrap_or(RosVersion::ROS1), field_type) {
-                md5sum_content.push_str(&format!(
-                    "{} {}\n",
-                    field.field_type, field.field_name
-                ));
+                md5sum_content.push_str(&format!("{} {}\n", field.field_type, field.field_name));
             } else {
                 let field_full_name = format!(
                     "{}/{}",
@@ -106,7 +100,10 @@ impl MessageFile {
 
         // Subtract the trailing newline
         let md5sum = md5::compute(&md5sum_content.trim_end().as_bytes());
-        log::trace!("Message type: {} calculated with md5sum: {md5sum:x}", parsed.get_full_name());
+        log::trace!(
+            "Message type: {} calculated with md5sum: {md5sum:x}",
+            parsed.get_full_name()
+        );
         Some(format!("{md5sum:x}"))
     }
 }

--- a/roslibrust_codegen/src/lib.rs
+++ b/roslibrust_codegen/src/lib.rs
@@ -424,6 +424,7 @@ mod test {
 
     /// Confirms we don't panic on ros1_test_msgs parsing
     #[test]
+    #[cfg_attr(not(feature = "ros1_test"), ignore)]
     fn generate_ok_on_ros1_test_msgs() {
         let assets_path = concat!(env!("CARGO_MANIFEST_DIR"), "/../assets/ros1_test_msgs");
 
@@ -433,6 +434,7 @@ mod test {
 
     /// Confirms we don't panic on ros2_test_msgs parsing
     #[test]
+    #[cfg_attr(not(feature = "ros2_test"), ignore)]
     fn generate_ok_on_ros2_test_msgs() {
         let assets_path = concat!(env!("CARGO_MANIFEST_DIR"), "/../assets/ros2_test_msgs");
 

--- a/roslibrust_codegen/src/lib.rs
+++ b/roslibrust_codegen/src/lib.rs
@@ -158,31 +158,9 @@ pub fn find_and_parse_ros_messages(
         "Codegen is looking in following paths for files: {:?}",
         &search_paths
     );
-    let mut packages = utils::crawl(search_paths.clone());
+    let packages = utils::crawl(search_paths.clone());
     // Check for duplicate package names
-    if packages.len() >= 2 {
-        for (pkg_idx_a, pkg_a) in packages[..packages.len() - 1].iter().enumerate() {
-            for (pkg_idx_b, pkg_b) in packages[pkg_idx_a + 1..].iter().enumerate() {
-                if pkg_idx_a != pkg_idx_b {
-                    if pkg_a.name == pkg_b.name {
-                        log::warn!(
-                            "Duplicate package found: {}. Discovered at paths: ({}, {})",
-                            pkg_a.name,
-                            pkg_a.path.display(),
-                            pkg_b.path.display()
-                        );
-                        log::warn!(
-                            "Proceeding with the package found at the first path: {}",
-                            pkg_a.path.display()
-                        );
-                    }
-                }
-            }
-        }
-        // Delete all of the duplicates (deletes the latter occurrences in the set)
-        packages.dedup_by(|a, b| a.name == b.name);
-    }
-
+    let packages = utils::deduplicate_packages(packages);
     if packages.len() == 0 {
         log::warn!(
             "No packages found while searching in: {search_paths:?}, relative to {:?}",
@@ -226,6 +204,7 @@ pub fn find_and_parse_ros_messages(
         })
         .flatten()
         .collect::<Vec<_>>();
+
     message_files.extend_from_slice(&service_files[..]);
     parse_ros_files(message_files)
 }

--- a/roslibrust_codegen/src/lib.rs
+++ b/roslibrust_codegen/src/lib.rs
@@ -8,7 +8,7 @@ use std::fmt::Debug;
 use std::path::PathBuf;
 use utils::Package;
 
-pub mod gen;
+mod gen;
 use gen::*;
 mod parse;
 use parse::*;

--- a/roslibrust_codegen/src/parse.rs
+++ b/roslibrust_codegen/src/parse.rs
@@ -1,9 +1,6 @@
-use proc_macro2::TokenStream;
-use quote::{quote, ToTokens};
-use serde::de::DeserializeOwned;
 use std::{
     collections::HashMap,
-    path::{Path, PathBuf},
+    path::{Path, PathBuf}, fmt::Display,
 };
 
 use crate::utils::{Package, RosVersion};
@@ -26,7 +23,7 @@ lazy_static::lazy_static! {
         ("string", "::std::string::String"),
         ("time", "::roslibrust_codegen::integral_types::Time"),
         ("duration", "::roslibrust_codegen::integral_types::Duration"),
-        ("Header", "Header"),
+        //("Header", "Header"),
     ].into_iter().collect();
 
     pub static ref ROS_2_TYPE_TO_RUST_TYPE_MAP: HashMap<&'static str, &'static str> = vec![
@@ -50,6 +47,38 @@ lazy_static::lazy_static! {
     ].into_iter().collect();
 }
 
+pub fn is_intrinsic_type(version: RosVersion, ros_type: &str) -> bool {
+    match version {
+        RosVersion::ROS1 => ROS_TYPE_TO_RUST_TYPE_MAP.contains_key(ros_type),
+        RosVersion::ROS2 => ROS_2_TYPE_TO_RUST_TYPE_MAP.contains_key(ros_type),
+    }
+}
+
+pub fn convert_ros_type_to_rust_type(version: RosVersion, ros_type: &str) -> Option<&'static str> {
+    match version {
+        RosVersion::ROS1 => ROS_TYPE_TO_RUST_TYPE_MAP.get(ros_type).copied(),
+        RosVersion::ROS2 => ROS_2_TYPE_TO_RUST_TYPE_MAP.get(ros_type).copied(),
+    }
+}
+
+/// Stores the ROS string representation of a literal
+#[derive(Clone, Debug)]
+pub struct RosLiteral {
+    pub inner: String,
+}
+
+impl std::fmt::Display for RosLiteral {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+
+impl From<String> for RosLiteral {
+    fn from(value: String) -> Self {
+        Self { inner: value }
+    }
+}
+
 /// Describes the type for an individual field in a message
 #[derive(PartialEq, Eq, Hash, Debug, Clone)]
 pub struct FieldType {
@@ -63,14 +92,23 @@ pub struct FieldType {
     pub is_vec: bool,
 }
 
+impl Display for FieldType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.is_vec {
+            f.write_fmt(format_args!("{}[]", self.field_type))
+        } else {
+            f.write_fmt(format_args!("{}", self.field_type))
+        }
+    }
+}
+
 /// Describes all information for an individual field
 #[derive(Clone, Debug)]
 pub struct FieldInfo {
     pub field_type: FieldType,
     pub field_name: String,
     // Exists if this is a ros2 message field with a default value
-    // Contains a literal token representing the value, and bool indicating if the value is static.
-    pub default: Option<TokenStream>,
+    pub default: Option<RosLiteral>,
 }
 
 // Because TokenStream doesn't impl PartialEq we have to do it manually for FieldInfo
@@ -87,7 +125,7 @@ impl PartialEq for FieldInfo {
 pub struct ConstantInfo {
     pub constant_type: String,
     pub constant_name: String,
-    pub constant_value: TokenStream,
+    pub constant_value: RosLiteral,
 }
 
 // Because TokenStream doesn't impl PartialEq we have to do it manually for ConstantInfo
@@ -119,6 +157,10 @@ impl ParsedMessageFile {
                 && (field.field_type.package_name.is_none()
                     || field.field_type.package_name == Some(String::from("std_msgs")))
         })
+    }
+
+    pub fn get_full_name(&self) -> String {
+        format!("{}/{}", self.package, self.name)
     }
 }
 
@@ -160,11 +202,7 @@ fn parse_field(line: &str, pkg: &Package, msg_name: &str) -> FieldInfo {
                 if remainder.is_empty() {
                     None
                 } else {
-                    Some(parse_ros_value(
-                        &field_type.field_type,
-                        remainder,
-                        field_type.is_vec,
-                    ))
+                    Some(remainder.to_owned().into())
                 }
             }
             None => {
@@ -195,12 +233,10 @@ fn parse_constant_field(line: &str, pkg: &Package) -> ConstantInfo {
     }
 
     let constant_value = line[sep + equal_after_sep + 1..].trim().to_string();
-    // TODO bug here, explicitly not handling constant vec until we can manage static array generation
-    let constant_value = parse_ros_value(&constant_type, &constant_value, false);
     ConstantInfo {
         constant_type,
         constant_name,
-        constant_value,
+        constant_value: constant_value.into(),
     }
 }
 
@@ -331,29 +367,20 @@ fn strip_comments(line: &str) -> &str {
 fn parse_field_type(type_str: &str, is_vec: bool, pkg: &Package) -> FieldType {
     let items = type_str.split('/').collect::<Vec<&str>>();
 
-    // Select which type conversion map to use depending on package version
-    let prop_map: &HashMap<&'static str, &'static str> = match pkg.version {
-        Some(RosVersion::ROS1) => &ROS_TYPE_TO_RUST_TYPE_MAP,
-        Some(RosVersion::ROS2) => &ROS_2_TYPE_TO_RUST_TYPE_MAP,
-        None => {
-            // If we couldn't determine the package type, assume ROS1 for now
-            &ROS_TYPE_TO_RUST_TYPE_MAP
-        }
-    };
-
     if items.len() == 1 {
         // If there is only one item (no package redirect)
+        let pkg_version = pkg.version.unwrap_or(RosVersion::ROS1);
         FieldType {
-            package_name: if prop_map.contains_key(type_str) {
+            package_name: if is_intrinsic_type(pkg_version, type_str) {
                 // If it is a fundamental type, no package
-                if items[0] == "Header" {
-                    Some("std_msgs".to_owned())
-                } else {
-                    None
-                }
+                None
             } else {
                 // Otherwise it is referencing another message in the same package
-                Some(pkg.name.clone())
+                if type_str == "Header" {
+                    Some("std_msgs".to_owned())
+                } else {
+                    Some(pkg.name.clone())
+                }
             },
             field_type: items[0].to_string(),
             is_vec,
@@ -396,73 +423,6 @@ fn parse_type(type_str: &str, pkg: &Package) -> FieldType {
         }
         _ => {
             panic!("Found malformed type: {type_str}");
-        }
-    }
-}
-
-// Converts a ROS string to a literal value
-// Not intended to be called directly, but only via parse_ros_value.
-// Wraps a serde_json deserialize call with our style of error handling.
-fn generic_parse_value<T: DeserializeOwned + ToTokens + std::fmt::Debug>(
-    value: &str,
-    is_vec: bool,
-) -> TokenStream {
-    if is_vec {
-        let parsed: Vec<T> = serde_json::from_str(value).expect(
-            &format!("Failed to parse a literal value in a message file to the corresponding rust type: {value} to {}", std::any::type_name::<T>())
-        );
-        let vec_str = format!("vec!{parsed:?}");
-        quote! { #vec_str }
-    } else {
-        let parsed: T = serde_json::from_str(value).expect(
-            &format!("Failed to parse a literal value in a message file to the corresponding rust type: {value} to {}", std::any::type_name::<T>())
-        );
-        quote! { #parsed }
-    }
-}
-
-/// For a given, which is either a ROS constant or default, parse the constant and convert it into a rust TokenStream
-/// which represents the same literal value. This handles frustrating edge cases that are not well documented features
-/// in either ROS1 or ROS2 such as:
-/// - `f32[] MY_CONST_ARRAY=[0, 1]` we have to convert the value of the constant to `vec![0.0, 1.0]`
-/// - `string[] names_field ['first', "second"]` we have to convert the default value to `vec!["first".to_string(), "second".to_string()]
-/// Note: I could find NO documentation from ROS about what was actually legal or expected for these value expressions
-/// Note: ROS says "strings are not escaped". No idea how the eff I'm actually supposed to handle that so likely bugs...
-/// Note: No idea of "constant arrays" are intended to be supported in ROS...
-/// `ros_type` -- Expects the string key of the determined rust type to hold the value. Should come from one of the type map constants.
-/// `value` -- Expects the trimmed string containing only the value expression
-/// `is_vec` -- True iff the type is an array type
-/// TODO I'd like this to take FieldType, but want it to also work with constants...
-fn parse_ros_value(ros_type: &str, value: &str, is_vec: bool) -> TokenStream {
-    match ros_type {
-        "bool" => generic_parse_value::<bool>(value, is_vec),
-        "float64" => generic_parse_value::<f64>(value, is_vec),
-        "float32" => generic_parse_value::<f32>(value, is_vec),
-        "uint8" | "char" | "byte" => generic_parse_value::<u8>(value, is_vec),
-        "int8" => generic_parse_value::<i8>(value, is_vec),
-        "uint16" => generic_parse_value::<u16>(value, is_vec),
-        "int16" => generic_parse_value::<i16>(value, is_vec),
-        "uint32" => generic_parse_value::<u32>(value, is_vec),
-        "int32" => generic_parse_value::<i32>(value, is_vec),
-        "uint64" => generic_parse_value::<u64>(value, is_vec),
-        "int64" => generic_parse_value::<i64>(value, is_vec),
-        "string" => {
-            // String is a special case because of quotes and to_string()
-            if is_vec {
-                // TODO there is a bug here, no idea how I should be attempting to convert / escape single quotes here...
-                let parsed: Vec<String> = serde_json::from_str(value).expect(
-            &format!("Failed to parse a literal value in a message file to the corresponding rust type: {value} to Vec<String>"));
-                let vec_str = format!("{parsed:?}.iter().map(|x| x.to_string()).collect()");
-                quote! { #vec_str }
-            } else {
-                // Halfass attempt to deal with ROS's string escaping / quote bullshit
-                let value = &value.replace("\'", "\"");
-                let parsed: String = serde_json::from_str(value).expect(&format!("Failed to parse a literal value in a message file to the corresponding rust type: {value} to String"));
-                quote! { #parsed }
-            }
-        }
-        _ => {
-            panic!("Found default for type which does not support default: {ros_type}");
         }
     }
 }

--- a/roslibrust_codegen/src/parse.rs
+++ b/roslibrust_codegen/src/parse.rs
@@ -24,7 +24,6 @@ lazy_static::lazy_static! {
         ("string", "::std::string::String"),
         ("time", "::roslibrust_codegen::integral_types::Time"),
         ("duration", "::roslibrust_codegen::integral_types::Duration"),
-        //("Header", "Header"),
     ].into_iter().collect();
 
     pub static ref ROS_2_TYPE_TO_RUST_TYPE_MAP: HashMap<&'static str, &'static str> = vec![

--- a/roslibrust_codegen/src/parse.rs
+++ b/roslibrust_codegen/src/parse.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::HashMap,
-    path::{Path, PathBuf}, fmt::Display,
+    fmt::Display,
+    path::{Path, PathBuf},
 };
 
 use crate::utils::{Package, RosVersion};

--- a/roslibrust_codegen/src/utils.rs
+++ b/roslibrust_codegen/src/utils.rs
@@ -153,6 +153,18 @@ fn message_files_from_path(path: &Path, ext: &str) -> io::Result<Vec<PathBuf>> {
 }
 
 pub fn deduplicate_packages(packages: Vec<Package>) -> Vec<Package> {
+    fn package_name_fmt(pkg: &Package) -> String {
+        format!(
+            "{}_{}",
+            pkg.name,
+            match pkg.version {
+                Some(RosVersion::ROS1) => "1",
+                Some(RosVersion::ROS2) => "2",
+                None => "unknown",
+            }
+        )
+    }
+
     let mut package_map: HashMap<String, Package> = HashMap::new();
     for package in packages {
         if let Some(duplicate) = package_map.get(package.name.as_str()) {
@@ -168,10 +180,10 @@ pub fn deduplicate_packages(packages: Vec<Package>) -> Vec<Package> {
                     duplicate.path.display()
                 );
             } else {
-                package_map.insert(package.name.to_owned(), package);
+                package_map.insert(package_name_fmt(&package), package);
             }
         } else {
-            package_map.insert(package.name.to_owned(), package);
+            package_map.insert(package_name_fmt(&package), package);
         }
     }
 

--- a/roslibrust_codegen/src/utils.rs
+++ b/roslibrust_codegen/src/utils.rs
@@ -150,12 +150,16 @@ pub fn deduplicate_packages(packages: Vec<Package>) -> Vec<Package> {
     let mut package_map: HashMap<String, Package> = HashMap::new();
     for package in packages {
         if let Some(duplicate) = package_map.get(package.name.as_str()) {
-            log::warn!("Duplicate package found: {}. Discovered at paths: ({}, {})",
+            log::warn!(
+                "Duplicate package found: {}. Discovered at paths: ({}, {})",
                 package.name,
                 duplicate.path.display(),
-                package.path.display());
-            log::warn!("Proceeding with the package found at the first path: {}",
-                duplicate.path.display());
+                package.path.display()
+            );
+            log::warn!(
+                "Proceeding with the package found at the first path: {}",
+                duplicate.path.display()
+            );
         } else {
             package_map.insert(package.name.to_owned(), package);
         }
@@ -250,21 +254,23 @@ mod test {
     fn verify_deduplicate_packages() {
         // Wow I am so upset, I thought I was going insane
         // std::Vec::dedup_by only removes *consecutive* elements that are equal
-        let packages = vec![utils::Package {
-            name: "diagnostic_msgs".into(),
-            path: "/opt/ros/noetic/share/diagnostic_msgs".into(),
-            version: Some(utils::RosVersion::ROS1),
-        },
-        utils::Package {
-            name: "std_msgs".into(),
-            path: "/tmp/std_msgs".into(),
-            version: None,
-        },
-        utils::Package {
-            name: "diagnostic_msgs".into(),
-            path: "/code/assets/ros1_common_interfaces/common_msgs/diagnostic_msgs".into(),
-            version: Some(utils::RosVersion::ROS1),
-        }];
+        let packages = vec![
+            utils::Package {
+                name: "diagnostic_msgs".into(),
+                path: "/opt/ros/noetic/share/diagnostic_msgs".into(),
+                version: Some(utils::RosVersion::ROS1),
+            },
+            utils::Package {
+                name: "std_msgs".into(),
+                path: "/tmp/std_msgs".into(),
+                version: None,
+            },
+            utils::Package {
+                name: "diagnostic_msgs".into(),
+                path: "/code/assets/ros1_common_interfaces/common_msgs/diagnostic_msgs".into(),
+                version: Some(utils::RosVersion::ROS1),
+            },
+        ];
 
         let deduplicated = utils::deduplicate_packages(packages);
         assert_eq!(deduplicated.len(), 2);

--- a/roslibrust_codegen/src/utils.rs
+++ b/roslibrust_codegen/src/utils.rs
@@ -22,9 +22,9 @@ pub enum RosVersion {
     ROS2,
 }
 
-const CATKIN_IGNORE: &'static str = "CATKIN_IGNORE";
-const PACKAGE_FILE_NAME: &'static str = "package.xml";
-const ROS_PACKAGE_PATH_ENV_VAR: &'static str = "ROS_PACKAGE_PATH";
+const CATKIN_IGNORE: &str = "CATKIN_IGNORE";
+const PACKAGE_FILE_NAME: &str = "package.xml";
+const ROS_PACKAGE_PATH_ENV_VAR: &str = "ROS_PACKAGE_PATH";
 
 pub fn get_search_paths() -> Vec<PathBuf> {
     if let Ok(paths) = std::env::var(ROS_PACKAGE_PATH_ENV_VAR) {
@@ -35,7 +35,7 @@ pub fn get_search_paths() -> Vec<PathBuf> {
 
         paths
             .split(separator)
-            .map(|path| PathBuf::from(path))
+            .map(PathBuf::from)
             .collect::<Vec<PathBuf>>()
     } else {
         log::warn!("No ROS_PACKAGE_PATH defined.");
@@ -203,8 +203,8 @@ fn parse_ros_package_info(
     use std::fs::File;
     use std::io::BufReader;
     use xml::reader::{EventReader, ParserConfig, XmlEvent};
-    const BUILD_TOOL_TAG: &'static str = "buildtool_depend";
-    const NAME_TAG: &'static str = "name";
+    const BUILD_TOOL_TAG: &str = "buildtool_depend";
+    const NAME_TAG: &str = "name";
 
     let file = File::open(&path)?;
     let reader = BufReader::new(file);

--- a/roslibrust_codegen_macro/src/lib.rs
+++ b/roslibrust_codegen_macro/src/lib.rs
@@ -12,7 +12,7 @@ impl Parse for RosLibRustMessagePaths {
         let mut paths = vec![];
         while let Ok(path) = input.parse::<syn::LitStr>() {
             paths.push(path.value().into());
-            if let Ok(_) = input.parse::<Token![,]>() {
+            if input.parse::<Token![,]>().is_ok() {
                 continue;
             } else {
                 break;

--- a/roslibrust_codegen_macro/src/lib.rs
+++ b/roslibrust_codegen_macro/src/lib.rs
@@ -25,6 +25,9 @@ impl Parse for RosLibRustMessagePaths {
 /// Given a list of paths, generates struct definitions and trait impls for any
 /// ros messages found within those paths.
 /// Paths are relative to where rustc is being invoked from your mileage may vary.
+///
+/// In addition to provided paths, this will search paths found in the environment
+/// variable ROS_PACKAGE_PATH.
 #[proc_macro]
 pub fn find_and_generate_ros_messages(input_stream: TokenStream) -> TokenStream {
     let RosLibRustMessagePaths { paths } =
@@ -47,4 +50,15 @@ pub fn find_and_generate_ros_messages_relative_to_manifest_dir(
     }
 
     roslibrust_codegen::find_and_generate_ros_messages(paths).into()
+}
+
+/// Similar to `find_and_generate_ros_messages`, but does not search the
+/// `ROS_PACKAGE_PATH` environment variable paths (useful in some situations).
+#[proc_macro]
+pub fn find_and_generate_ros_messages_without_ros_package_path(
+    input_stream: TokenStream,
+) -> TokenStream {
+    let RosLibRustMessagePaths { paths } =
+        parse_macro_input!(input_stream as RosLibRustMessagePaths);
+    roslibrust_codegen::find_and_generate_ros_messages_without_ros_package_path(paths).into()
 }

--- a/roslibrust_test/src/main.rs
+++ b/roslibrust_test/src/main.rs
@@ -25,11 +25,13 @@ lazy_static! {
 /// This main function is used to generate the contents of ros1.rs, ros2.rs
 fn main() {
     env_logger::init();
-    let tokens = roslibrust_codegen::find_and_generate_ros_messages((*ROS_1_PATHS).clone());
+    let tokens = roslibrust_codegen::find_and_generate_ros_messages_without_ros_package_path(
+        (*ROS_1_PATHS).clone(),
+    );
     let source = format_rust_source(tokens.to_string().as_str()).to_string();
     let _ = std::fs::write(concat!(env!("CARGO_MANIFEST_DIR"), "/src/ros1.rs"), source);
 
-    let tokens = roslibrust_codegen::find_and_generate_ros_messages(vec![
+    let tokens = roslibrust_codegen::find_and_generate_ros_messages_without_ros_package_path(vec![
         ROS_2_PATH.into(),
         ROS_2_TEST_PATH.into(),
     ]);

--- a/roslibrust_test/src/main.rs
+++ b/roslibrust_test/src/main.rs
@@ -71,7 +71,9 @@ mod test {
     /// Confirms that codegen has been run and changes committed
     #[test]
     fn ros1_lib_is_up_to_date() {
-        let tokens = roslibrust_codegen::find_and_generate_ros_messages((*ROS_1_PATHS).clone());
+        let tokens = roslibrust_codegen::find_and_generate_ros_messages_without_ros_package_path(
+            (*ROS_1_PATHS).clone(),
+        );
         let source = format_rust_source(tokens.to_string().as_str()).to_string();
         let lib_path = env!("CARGO_MANIFEST_DIR").to_string() + "/src/ros1.rs";
         let lib_contents =
@@ -89,7 +91,9 @@ mod test {
     /// Confirms that codegen has been run and changes committed
     #[test]
     fn ros2_lib_is_up_to_date() {
-        let tokens = roslibrust_codegen::find_and_generate_ros_messages((*ROS_2_PATHS).clone());
+        let tokens = roslibrust_codegen::find_and_generate_ros_messages_without_ros_package_path(
+            (*ROS_2_PATHS).clone(),
+        );
         let source = format_rust_source(tokens.to_string().as_str()).to_string();
         let lib_path = env!("CARGO_MANIFEST_DIR").to_string() + "/src/ros2.rs";
         let lib_contents =


### PR DESCRIPTION
* Added calculation of md5sum. Checked a handful against generated header files, specifically `Image.msg` which includes an array and a Header and `TransformStamped.msg` which includes a Header and another msg datatype from the same package.
* Added helper methods throughout to make structs a little smarter and reduce duplicated code
* Adjusted pipeline to exclusively use ROS types and data directly derived from msg file during parsing and to not do any Rust code generation until we are doing generation (specifically around literals for constants).