### PR TITLE
Rough first pass on generation of C++ header files for messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "clap"
+version = "4.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f13b9c79b5d1dd500d20ef541215a6423c75829ef43117e1b4d17fd8af0b5d76"
+dependencies = [
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "is-terminal",
+ "once_cell",
+ "strsim",
+ "termcolor",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "783fe232adfca04f90f56201b26d79682d4cd2625e0bc7290b95123afe558ade"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
 name = "colored"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -348,6 +385,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,10 +504,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "minijinja"
+version = "0.30.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18b0af1900a114a8183b10b4266a9a4fc2816afdb7089592492c8eadd07f1629"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "mio"
@@ -514,6 +572,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
 
 [[package]]
+name = "os_str_bytes"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,6 +619,30 @@ name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -662,6 +750,7 @@ version = "0.6.0"
 dependencies = [
  "lazy_static",
  "log",
+ "md5",
  "proc-macro2",
  "quote",
  "serde",
@@ -680,6 +769,19 @@ dependencies = [
  "quote",
  "roslibrust_codegen",
  "syn",
+]
+
+[[package]]
+name = "roslibrust_gencpp"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "env_logger",
+ "log",
+ "minijinja",
+ "roslibrust_codegen",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -830,6 +932,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,6 @@ members = [
     "roslibrust",
     "roslibrust_codegen",
     "roslibrust_codegen_macro",
+    "roslibrust_gencpp",
     "roslibrust_test"
 ]

--- a/roslibrust_codegen/src/gen.rs
+++ b/roslibrust_codegen/src/gen.rs
@@ -4,11 +4,9 @@ use serde::de::DeserializeOwned;
 use std::str::FromStr;
 use syn::parse_quote;
 
-use crate::parse::{
-    convert_ros_type_to_rust_type, ConstantInfo, FieldInfo, ParsedMessageFile, ParsedServiceFile,
-    RosLiteral,
-};
+use crate::parse::{convert_ros_type_to_rust_type, ParsedMessageFile, ParsedServiceFile};
 use crate::utils::RosVersion;
+use crate::{ConstantInfo, FieldInfo, RosLiteral};
 
 fn derive_attrs() -> Vec<syn::Attribute> {
     // TODO we should look into using $crate here...

--- a/roslibrust_codegen/src/lib.rs
+++ b/roslibrust_codegen/src/lib.rs
@@ -58,7 +58,11 @@ impl MessageFile {
     ) -> Option<Self> {
         let md5sum = Self::compute_md5sum(&parsed, graph)?;
         let is_fixed_length = Self::determine_if_fixed_length(&parsed, graph)?;
-        Some(MessageFile { parsed, md5sum, is_fixed_length })
+        Some(MessageFile {
+            parsed,
+            md5sum,
+            is_fixed_length,
+        })
     }
 
     pub fn get_package_name(&self) -> String {
@@ -139,7 +143,8 @@ impl MessageFile {
                 }
             } else {
                 let field_msg = graph.get(field.get_full_name().as_str())?;
-                let field_is_fixed_length  = Self::determine_if_fixed_length(&field_msg.parsed, graph)?;
+                let field_is_fixed_length =
+                    Self::determine_if_fixed_length(&field_msg.parsed, graph)?;
                 if !field_is_fixed_length {
                     return Some(false);
                 }
@@ -218,8 +223,7 @@ impl FieldInfo {
     pub fn get_full_name(&self) -> String {
         format!(
             "{}/{}",
-            self
-                .field_type
+            self.field_type
                 .package_name
                 .as_ref()
                 .unwrap_or_else(|| panic!("Expected package name for field {self:#?}")),

--- a/roslibrust_codegen/src/lib.rs
+++ b/roslibrust_codegen/src/lib.rs
@@ -4,7 +4,7 @@ use quote::quote;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::collections::{BTreeMap, VecDeque};
-use std::fmt::Debug;
+use std::fmt::{Debug, Display};
 use std::path::PathBuf;
 use utils::Package;
 
@@ -48,6 +48,7 @@ pub trait RosServiceType {
 pub struct MessageFile {
     pub(crate) parsed: ParsedMessageFile,
     pub(crate) md5sum: String,
+    pub(crate) is_fixed_length: bool,
 }
 
 impl MessageFile {
@@ -56,7 +57,16 @@ impl MessageFile {
         graph: &BTreeMap<String, MessageFile>,
     ) -> Option<Self> {
         let md5sum = Self::compute_md5sum(&parsed, graph)?;
-        Some(MessageFile { parsed, md5sum })
+        let is_fixed_length = Self::determine_if_fixed_length(&parsed, graph)?;
+        Some(MessageFile { parsed, md5sum, is_fixed_length })
+    }
+
+    pub fn get_package_name(&self) -> String {
+        self.parsed.package.clone()
+    }
+
+    pub fn get_short_name(&self) -> String {
+        self.parsed.name.clone()
     }
 
     pub fn get_full_name(&self) -> String {
@@ -65,6 +75,14 @@ impl MessageFile {
 
     pub fn get_md5sum(&self) -> &str {
         self.md5sum.as_str()
+    }
+
+    pub fn get_fields(&self) -> &[FieldInfo] {
+        &self.parsed.fields
+    }
+
+    pub fn is_fixed_length(&self) -> bool {
+        self.is_fixed_length
     }
 
     fn compute_md5sum(
@@ -106,6 +124,29 @@ impl MessageFile {
         );
         Some(format!("{md5sum:x}"))
     }
+
+    fn determine_if_fixed_length(
+        parsed: &ParsedMessageFile,
+        graph: &BTreeMap<String, MessageFile>,
+    ) -> Option<bool> {
+        for field in &parsed.fields {
+            if field.field_type.is_vec {
+                return Some(false);
+            }
+            if field.field_type.package_name.is_none() {
+                if field.field_type.field_type == "string" {
+                    return Some(false);
+                }
+            } else {
+                let field_msg = graph.get(field.get_full_name().as_str())?;
+                let field_is_fixed_length  = Self::determine_if_fixed_length(&field_msg.parsed, graph)?;
+                if !field_is_fixed_length {
+                    return Some(false);
+                }
+            }
+        }
+        Some(true)
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -113,6 +154,95 @@ pub struct ServiceFile {
     pub(crate) parsed: ParsedServiceFile,
     pub request: MessageFile,
     pub response: MessageFile,
+}
+
+/// Stores the ROS string representation of a literal
+#[derive(Clone, Debug)]
+pub struct RosLiteral {
+    pub inner: String,
+}
+
+impl Display for RosLiteral {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.inner, f)
+    }
+}
+
+impl From<String> for RosLiteral {
+    fn from(value: String) -> Self {
+        Self { inner: value }
+    }
+}
+
+/// Describes the type for an individual field in a message
+#[derive(PartialEq, Eq, Hash, Debug, Clone)]
+pub struct FieldType {
+    // Present when an externally referenced package is used
+    // Note: support for messages within same package is spotty...
+    pub package_name: Option<String>,
+    // Explicit text of type without array specifier
+    pub field_type: String,
+    // true iff "[]" or "[#]" are found
+    // Note: no support for fixed size arrays yet
+    pub is_vec: bool,
+}
+
+impl std::fmt::Display for FieldType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.is_vec {
+            f.write_fmt(format_args!("{}[]", self.field_type))
+        } else {
+            f.write_fmt(format_args!("{}", self.field_type))
+        }
+    }
+}
+
+/// Describes all information for an individual field
+#[derive(Clone, Debug)]
+pub struct FieldInfo {
+    pub field_type: FieldType,
+    pub field_name: String,
+    // Exists if this is a ros2 message field with a default value
+    pub default: Option<RosLiteral>,
+}
+
+// Because TokenStream doesn't impl PartialEq we have to do it manually for FieldInfo
+impl PartialEq for FieldInfo {
+    fn eq(&self, other: &Self) -> bool {
+        self.field_type == other.field_type && self.field_name == other.field_name
+        // && self.default == other.default
+    }
+}
+
+impl FieldInfo {
+    pub fn get_full_name(&self) -> String {
+        format!(
+            "{}/{}",
+            self
+                .field_type
+                .package_name
+                .as_ref()
+                .unwrap_or_else(|| panic!("Expected package name for field {self:#?}")),
+            self.field_type.field_type
+        )
+    }
+}
+
+/// Describes all information for a constant within a message
+/// Note: Constants are not fully supported yet (waiting on codegen support)
+#[derive(Clone, Debug)]
+pub struct ConstantInfo {
+    pub constant_type: String,
+    pub constant_name: String,
+    pub constant_value: RosLiteral,
+}
+
+// Because TokenStream doesn't impl PartialEq we have to do it manually for ConstantInfo
+impl PartialEq for ConstantInfo {
+    fn eq(&self, other: &Self) -> bool {
+        self.constant_type == other.constant_type && self.constant_name == other.constant_name
+        // && self.constant_value == other.constant_value
+    }
 }
 
 /// Searches a list of paths for ROS packages and generates struct definitions

--- a/roslibrust_codegen/src/parse.rs
+++ b/roslibrust_codegen/src/parse.rs
@@ -1,10 +1,9 @@
+use crate::utils::{Package, RosVersion};
+use crate::{ConstantInfo, FieldInfo, FieldType};
 use std::{
     collections::HashMap,
-    fmt::Display,
     path::{Path, PathBuf},
 };
-
-use crate::utils::{Package, RosVersion};
 
 lazy_static::lazy_static! {
     pub static ref ROS_TYPE_TO_RUST_TYPE_MAP: HashMap<&'static str, &'static str> = vec![
@@ -58,81 +57,6 @@ pub fn convert_ros_type_to_rust_type(version: RosVersion, ros_type: &str) -> Opt
     match version {
         RosVersion::ROS1 => ROS_TYPE_TO_RUST_TYPE_MAP.get(ros_type).copied(),
         RosVersion::ROS2 => ROS_2_TYPE_TO_RUST_TYPE_MAP.get(ros_type).copied(),
-    }
-}
-
-/// Stores the ROS string representation of a literal
-#[derive(Clone, Debug)]
-pub struct RosLiteral {
-    pub inner: String,
-}
-
-impl std::fmt::Display for RosLiteral {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.inner.fmt(f)
-    }
-}
-
-impl From<String> for RosLiteral {
-    fn from(value: String) -> Self {
-        Self { inner: value }
-    }
-}
-
-/// Describes the type for an individual field in a message
-#[derive(PartialEq, Eq, Hash, Debug, Clone)]
-pub struct FieldType {
-    // Present when an externally referenced package is used
-    // Note: support for messages within same package is spotty...
-    pub package_name: Option<String>,
-    // Explicit text of type without array specifier
-    pub field_type: String,
-    // true iff "[]" or "[#]" are found
-    // Note: no support for fixed size arrays yet
-    pub is_vec: bool,
-}
-
-impl Display for FieldType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.is_vec {
-            f.write_fmt(format_args!("{}[]", self.field_type))
-        } else {
-            f.write_fmt(format_args!("{}", self.field_type))
-        }
-    }
-}
-
-/// Describes all information for an individual field
-#[derive(Clone, Debug)]
-pub struct FieldInfo {
-    pub field_type: FieldType,
-    pub field_name: String,
-    // Exists if this is a ros2 message field with a default value
-    pub default: Option<RosLiteral>,
-}
-
-// Because TokenStream doesn't impl PartialEq we have to do it manually for FieldInfo
-impl PartialEq for FieldInfo {
-    fn eq(&self, other: &Self) -> bool {
-        self.field_type == other.field_type && self.field_name == other.field_name
-        // && self.default == other.default
-    }
-}
-
-/// Describes all information for a constant within a message
-/// Note: Constants are not fully supported yet (waiting on codegen support)
-#[derive(Clone, Debug)]
-pub struct ConstantInfo {
-    pub constant_type: String,
-    pub constant_name: String,
-    pub constant_value: RosLiteral,
-}
-
-// Because TokenStream doesn't impl PartialEq we have to do it manually for ConstantInfo
-impl PartialEq for ConstantInfo {
-    fn eq(&self, other: &Self) -> bool {
-        self.constant_type == other.constant_type && self.constant_name == other.constant_name
-        // && self.constant_value == other.constant_value
     }
 }
 

--- a/roslibrust_codegen/src/utils.rs
+++ b/roslibrust_codegen/src/utils.rs
@@ -131,19 +131,17 @@ pub fn get_service_files(pkg: &Package) -> io::Result<Vec<PathBuf>> {
 
 fn message_files_from_path(path: &Path, ext: &str) -> io::Result<Vec<PathBuf>> {
     let mut msg_files = vec![];
-    for entry in std::fs::read_dir(path)? {
-        if let Ok(entry) = entry {
-            if entry.path().as_path().is_dir() {
-                msg_files = [
-                    msg_files,
-                    message_files_from_path(entry.path().as_path(), ext)?,
-                ]
-                .concat()
-            } else if entry.path().as_path().is_file() {
-                if let Some(extension) = entry.path().extension() {
-                    if extension.to_str().unwrap() == ext {
-                        msg_files.push(entry.path())
-                    }
+    for entry in (std::fs::read_dir(path)?).flatten() {
+        if entry.path().as_path().is_dir() {
+            msg_files = [
+                msg_files,
+                message_files_from_path(entry.path().as_path(), ext)?,
+            ]
+            .concat()
+        } else if entry.path().as_path().is_file() {
+            if let Some(extension) = entry.path().extension() {
+                if extension.to_str().unwrap() == ext {
+                    msg_files.push(entry.path())
                 }
             }
         }

--- a/roslibrust_gencpp/Cargo.toml
+++ b/roslibrust_gencpp/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "roslibrust_gencpp"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "roslibrust_gencpp"
+path = "src/lib.rs"
+
+[[bin]]
+name = "gencpp"
+path = "src/main.rs"
+
+[dependencies]
+clap = { version = "4.1", features = ["derive"] }
+env_logger = "0.10"
+log = "0.4"
+minijinja = "0.30"
+roslibrust_codegen = { path = "../roslibrust_codegen" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/roslibrust_gencpp/assets/msg.h.j2
+++ b/roslibrust_gencpp/assets/msg.h.j2
@@ -1,0 +1,207 @@
+#ifndef {{ spec.package|upper }}_MESSAGE_{{ spec.short_name|upper }}
+#define {{ spec.package|upper }}_MESSAGE_{{ spec.short_name|upper }}
+
+#include <string>
+#include <vector>
+#include <memory>
+
+#include <ros/types.h>
+#include <ros/serialization.h>
+#include <ros/builtin_message_traits.h>
+#include <ros/message_operations.h>
+
+{% for field in spec.fields %}
+#include <{{ field.package }}/{{ field.field_type }}.h
+{%- endfor %}
+
+namespace {{ spec.package }} {
+
+template <class ContainerAllocator>
+struct {{ spec.short_name }}_
+{
+  typedef {{ spec.short_name }}_<ContainerAllocator> Type;
+
+  {{ spec.short_name }}_()
+    : {{ spec.fields|map(attribute="name")|join('()\n    , ') }}() {
+  }
+
+  {{ spec.short_name }}_(const ContainerAllocator& _alloc)
+    : {{ spec.fields|map(attribute="name")|join('(_alloc)\n    , ') }}(_alloc) {
+    (void)_alloc;
+  }
+
+  {% for field in spec.fields %}
+  typedef ::{{ field.package }}::{{ field.field_type }}_<ContainerAllocator> _{{ field.name }}_type;
+  _{{ field.name }}_type {{ field.name }};
+  {%- endfor %}
+
+  typedef boost::shared_ptr< ::{{ spec.package }}::{{ spec.short_name }}_<ContainerAllocator>> Ptr;
+  typedef boost::shared_ptr< ::{{ spec.package }}::{{ spec.short_name }}_<ContainerAllocator> const> ConstPtr;
+
+}; // struct {{ spec.short_name }}_
+
+typedef ::{{ spec.package }}::{{ spec.short_name }}_<std::allocator<void>> {{ spec.short_name }};
+
+typedef boost::shared_ptr< ::{{ spec.package }}::{{ spec.short_name }}> {{ spec.short_name }}Ptr;
+typedef boost::shared_ptr< ::{{ spec.package }}::{{ spec.short_name }} const> {{ spec.short_name }}ConstPtr;
+
+// constants requiring out of line definition
+
+
+template<typename ContainerAllocator>
+std::ostream& operator<<(std::ostream& s, const ::{{ spec.package }}::{{ spec.short_name }}_<ContainerAllocator> & v)
+{
+ros::message_operations::Printer< ::{{ spec.package }}::{{ spec.short_name }}_<ContainerAllocator> >::stream(s, "", v);
+return s;
+}
+
+template<typename ContainerAllocator1, typename ContainerAllocator2>
+bool operator==(const ::{{ spec.package }}::{{ spec.short_name }}_<ContainerAllocator1> & lhs, const ::{{ spec.package }}::{{ spec.short_name }}_<ContainerAllocator2> & rhs)
+{
+  return
+    {%- for field in spec.fields %}
+    lhs.{{ field.name }} == rhs.{{ field.name }} &&
+    {%- endfor %}
+    true;
+}
+
+template<typename ContainerAllocator1, typename ContainerAllocator2>
+bool operator!=(const ::{{ spec.package }}::{{ spec.short_name }}_<ContainerAllocator1> & lhs, const ::{{ spec.package }}::{{ spec.short_name }}_<ContainerAllocator2> & rhs)
+{
+  return !(lhs == rhs);
+}
+
+
+} // namespace {{ spec.package }}
+
+namespace ros
+{
+namespace message_traits
+{
+template <class ContainerAllocator>
+struct IsMessage< ::{{ spec.package }}::{{ spec.short_name }}_<ContainerAllocator>>
+  : TrueType
+  { };
+
+template <class ContainerAllocator>
+struct IsMessage< ::{{ spec.package }}::{{ spec.short_name }}_<ContainerAllocator> const>
+  : TrueType
+  { };
+
+template <class ContainerAllocator>
+struct IsFixedSize< ::{{ spec.package }}::{{ spec.short_name }}_<ContainerAllocator>>
+  : {% if is_fixed_length(spec) -%}
+    TrueType
+    {% else -%}
+    FalseType
+    {% endif -%}
+  { };
+
+template <class ContainerAllocator>
+struct IsFixedSize< ::{{ spec.package }}::{{ spec.short_name }}_<ContainerAllocator> const>
+  : {% if is_fixed_length(spec) -%}
+    TrueType
+    {% else -%}
+    FalseType
+    {% endif -%}
+  { };
+
+template <class ContainerAllocator>
+struct HasHeader< ::{{ spec.package }}::{{ spec.short_name }}_<ContainerAllocator>>
+  : {% if has_header(spec) -%}
+    TrueType
+    {% else -%}
+    FalseType
+    {% endif -%}
+  { };
+
+template <class ContainerAllocator>
+struct HasHeader< ::{{ spec.package }}::{{ spec.short_name }}_<ContainerAllocator> const>
+  : {% if has_header(spec) -%}
+    TrueType
+    {% else -%}
+    FalseType
+    {% endif -%}
+  { };
+
+template<class ContainerAllocator>
+struct MD5Sum< ::{{ spec.package }}::{{ spec.short_name }}_<ContainerAllocator>>
+{
+  static const char* value()
+  {
+    return "{{ spec.md5sum_first }}{{ spec.md5sum_second }}";
+  }
+
+  static const char* value(const ::{{ spec.package }}::{{ spec.short_name }}_<ContainerAllocator>&) { return value(); }
+  static const uint64_t static_value1 = 0x{{ spec.md5sum_first }}ULL;
+  static const uint64_t static_value2 = 0x{{ spec.md5sum_second }}ULL;
+};
+
+template<class ContainerAllocator>
+struct DataType< ::{{ spec.package }}::{{ spec.short_name }}_<ContainerAllocator>>
+{
+  static const char* value()
+  {
+    return "{{ spec.package }}/{{ spec.short_name }}";
+  }
+
+  static const char* value(const ::{{ spec.package }}::{{ spec.short_name }}_<ContainerAllocator>&) { return value(); }
+};
+
+template<class ContainerAllocator>
+struct Definition< ::{{ spec.package }}::{{ spec.short_name }}_<ContainerAllocator>>
+{
+  static const char* value()
+  {
+    return "{{ spec.definition }}";
+  }
+
+  static const char* value(const ::{{ spec.package }}::{{ spec.short_name }}_<ContainerAllocator>&) { return value(); }
+};
+
+} // namespace message_traits
+} // namespace ros
+
+namespace ros
+{
+namespace serialization
+{
+
+template<class ContainerAllocator>
+struct Serializer< ::{{ spec.package }}::{{ spec.short_name }}_<ContainerAllocator>>
+{
+  template<typename Stream, typename T> inline static void allInOne(Stream& stream, T m)
+  {
+    {%- for field in spec.fields %}
+    stream.next(m.{{ field.name }});
+    {%- endfor %}
+  }
+
+  ROS_DECLARE_ALLINONE_SERIALIZER
+}; // struct {{ spec.short_name }}_
+
+} // namespace serialization
+} // namespace ros
+
+namespace ros
+{
+namespace message_operations
+{
+
+template<class ContainerAllocator>
+struct Printer< ::{{ spec.package }}::{{ spec.short_name }}_<ContainerAllocator>>
+{
+  template<typename Stream> static void stream(Stream& s, const std::string& indent, const ::{{ spec.package }}::{{ spec.short_name }}_<ContainerAllocator>& v)
+  {
+    {%- for field in spec.fields %}
+    s << indent << "{{ field.name }}: ";
+    s << std::endl;
+    Printer< ::{{ field.package }}::{{ field.field_type }}_<ContainerAllocator>>::stream(s, indent + "  ", v.{{ field.name }});
+    {%- endfor %}
+  }
+};
+
+} // namespace message_operations
+} // namespace ros
+
+#endif // {{ spec.package|upper }}_MESSAGE_{{ spec.short_name|upper }}

--- a/roslibrust_gencpp/src/helpers.rs
+++ b/roslibrust_gencpp/src/helpers.rs
@@ -1,0 +1,29 @@
+use minijinja::value::Value;
+
+use crate::spec::MessageSpecification;
+
+pub fn has_header(value: Value) -> bool {
+    if let Ok(value) = serde_json::to_value(value) {
+        if let Ok(spec) = serde_json::from_value::<MessageSpecification>(value) {
+            spec.fields
+                .iter()
+                .any(|field| field.field_type.as_str() == "Header")
+        } else {
+            false
+        }
+    } else {
+        false
+    }
+}
+
+pub fn is_fixed_length(value: Value) -> bool {
+    if let Ok(value) = serde_json::to_value(value) {
+        if let Ok(spec) = serde_json::from_value::<MessageSpecification>(value) {
+            spec.is_fixed_length
+        } else {
+            false
+        }
+    } else {
+        false
+    }
+}

--- a/roslibrust_gencpp/src/lib.rs
+++ b/roslibrust_gencpp/src/lib.rs
@@ -1,0 +1,63 @@
+use minijinja::{context, Environment, Template};
+use roslibrust_codegen::MessageFile;
+use std::path::{Path, PathBuf};
+
+mod helpers;
+mod spec;
+
+use spec::MessageSpecification;
+
+const MESSAGE_HEADER_TMPL: &str =
+    include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/assets/msg.h.j2"));
+
+#[derive(Clone, Debug)]
+pub struct IncludedNamespace {
+    /// The package namespace being included
+    pub package: String,
+    /// The path to the package
+    pub path: PathBuf,
+}
+
+pub struct MessageGenOpts {
+    /// The package namespace for the generated message
+    pub package: String,
+    /// Include packages for resolving message dependencies
+    pub includes: Vec<IncludedNamespace>,
+}
+
+pub fn generate_message(
+    msg_path: &Path,
+    opts: &MessageGenOpts,
+) -> Result<String, minijinja::Error> {
+    let search_paths = opts.includes.iter().map(|inc| inc.path.clone()).collect();
+    let (messages, services) = roslibrust_codegen::find_and_parse_ros_messages(search_paths)
+        .unwrap_or_else(|_| panic!("Unable to find ROS messages"));
+    let (messages, _) = roslibrust_codegen::resolve_dependency_graph(messages, services).unwrap();
+
+    let mut env = Environment::new();
+    env.add_function("has_header", helpers::has_header);
+    env.add_function("is_fixed_length", helpers::is_fixed_length);
+    env.add_template("msg.h", MESSAGE_HEADER_TMPL).unwrap();
+
+    let message_name = msg_path.file_stem().unwrap().to_str().unwrap().to_owned();
+    match messages
+        .iter()
+        .find(|msg| msg.get_short_name() == message_name && msg.get_package_name() == opts.package)
+    {
+        Some(msg) => fill_message_template(&env.get_template("msg.h").unwrap(), msg),
+        None => Err(minijinja::Error::new(
+            minijinja::ErrorKind::UndefinedError,
+            "Message not found in search paths",
+        )),
+    }
+}
+
+fn fill_message_template(
+    template: &Template,
+    msg_data: &MessageFile,
+) -> Result<String, minijinja::Error> {
+    let context = context! {
+        spec => MessageSpecification::from_data(msg_data),
+    };
+    template.render(&context)
+}

--- a/roslibrust_gencpp/src/main.rs
+++ b/roslibrust_gencpp/src/main.rs
@@ -1,0 +1,43 @@
+use clap::Parser;
+use roslibrust_gencpp::IncludedNamespace;
+use std::{io::Write, path::PathBuf};
+
+#[derive(Parser, Debug)]
+struct Args {
+    /// Path to the input .msg file
+    #[arg(long = "msg", short = 'm')]
+    msg_path: PathBuf,
+    /// The package namespace for the generated message
+    #[arg(long, short)]
+    package: String,
+    /// Output directory for generated code
+    #[arg(long, short)]
+    output: PathBuf,
+    /// Include namespaces for message dependencies
+    #[arg(long, short = 'I', value_parser = include_namespace_parse)]
+    include: Option<Vec<IncludedNamespace>>,
+}
+
+fn include_namespace_parse(s: &str) -> Result<IncludedNamespace, String> {
+    let components = s.split(':').collect::<Vec<&str>>();
+    if components.len() == 2 {
+        let package = components[0].to_owned();
+        let path = PathBuf::from(components[1]);
+        Ok(IncludedNamespace { package, path })
+    } else {
+        Err(String::from("Expected format: 'PACKAGE:/some/path'"))
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init();
+    let args = Args::parse();
+    let opts = roslibrust_gencpp::MessageGenOpts {
+        package: args.package,
+        includes: args.include.unwrap_or_default(),
+    };
+    let generated_source = roslibrust_gencpp::generate_message(&args.msg_path, &opts)?;
+    let mut out_file = std::fs::File::create(args.output)?;
+    out_file.write_all(generated_source.as_bytes())?;
+    Ok(())
+}

--- a/roslibrust_gencpp/src/spec.rs
+++ b/roslibrust_gencpp/src/spec.rs
@@ -1,0 +1,51 @@
+use roslibrust_codegen::{FieldInfo, MessageFile};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Clone, Debug)]
+pub struct Field {
+    pub name: String,
+    pub field_type: String,
+    pub package: Option<String>,
+}
+
+impl From<&FieldInfo> for Field {
+    fn from(value: &FieldInfo) -> Self {
+        Self {
+            name: value.field_name.clone(),
+            field_type: value.field_type.field_type.clone(),
+            package: value.field_type.package_name.clone(),
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug)]
+pub struct MessageSpecification {
+    pub short_name: String,
+    pub package: String,
+    pub fields: Vec<Field>,
+    pub md5sum_first: String,
+    pub md5sum_second: String,
+    pub description: String,
+    pub is_fixed_length: bool,
+}
+
+impl MessageSpecification {
+    pub fn from_data(data: &MessageFile) -> Self {
+        let md5sum = data.get_md5sum();
+        let mut spec = Self {
+            short_name: data.get_short_name(),
+            package: data.get_package_name(),
+            fields: data.get_fields().iter().map(Field::from).collect(),
+            md5sum_first: String::from(&md5sum[..md5sum.len() / 2]),
+            md5sum_second: String::from(&md5sum[(md5sum.len() / 2)..]),
+            description: String::from("Not a real description"),
+            is_fixed_length: data.is_fixed_length(),
+        };
+        spec.fields.iter_mut().for_each(|field| {
+            if field.package.is_none() {
+                field.package = Some(data.get_package_name());
+            }
+        });
+        spec
+    }
+}


### PR DESCRIPTION
Currently missing support for constants. We have some peculiarities with our message generation which means it doesn't quite work like the official genmsg/gencpp tools yet (namely, it's not possible to call this without includes as that's how we find the file and returned the parsed version).

Can be invoked with
```
cargo run --bin gencpp -- -m assets/ros1_common_interfaces/std_msgs/msg/ColorRGBA.msg \
    -p std_msgs \
    -o /tmp/ColorRGBA.h \
    -Istd_msgs:assets/ros1_common_interfaces/std_msgs
```

This does not currently support services or constants. But I prefer to keep PRs small so I think those can come in later PRs. I think those should be included at a minimum before we publish the crate. I've also made public a whole lot of our parsed structures from `roslibrust_codegen`. Those are going to need docs.