### PR TITLE
Add uint64 to ros type list and replace C++ mapping for string

### DIFF
--- a/roslibrust_genmsg/src/cpp.rs
+++ b/roslibrust_genmsg/src/cpp.rs
@@ -20,7 +20,7 @@ lazy_static::lazy_static! {
         ("uint64", "uint64_t"),
         ("float32", "float"),
         ("float64", "double"),
-        ("string", "::std::string"),
+        ("string", "std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>>"),
         ("time", "::ros::Time"),
         ("duration", "::ros::Duration"),
     ].into_iter().map(|(k, v)| (k.to_owned(), v.to_owned())).collect();

--- a/roslibrust_genmsg/src/spec.rs
+++ b/roslibrust_genmsg/src/spec.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 pub static ROS_TYPENAMES: &[&str] = &[
     "bool", "int8", "uint8", "byte", "char", "int16", "uint16", "int32", "uint32", "int64",
-    "float32", "float64", "string", "time", "duration",
+    "uint64", "float32", "float64", "string", "time", "duration",
 ];
 
 #[derive(Deserialize, Serialize, Clone, Debug)]

--- a/roslibrust_genmsg/test_package/include/sensor_msgs/BatteryState.h
+++ b/roslibrust_genmsg/test_package/include/sensor_msgs/BatteryState.h
@@ -137,12 +137,12 @@ struct BatteryState_
     
     
       
-        typedef ::std::string _location_type;
+        typedef std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>> _location_type;
     _location_type location;
     
     
       
-        typedef ::std::string _serial_number_type;
+        typedef std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>> _serial_number_type;
     _serial_number_type serial_number;
 
   
@@ -417,12 +417,12 @@ struct Printer< ::sensor_msgs::BatteryState_<ContainerAllocator>>
     s << indent << "location: ";
     s << std::endl;
     
-    Printer< ::std::string>::stream(s, indent + "  ", v.location);
+    Printer< std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>>>::stream(s, indent + "  ", v.location);
     
     s << indent << "serial_number: ";
     s << std::endl;
     
-    Printer< ::std::string>::stream(s, indent + "  ", v.serial_number);
+    Printer< std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>>>::stream(s, indent + "  ", v.serial_number);
     
   }
 };

--- a/roslibrust_genmsg/test_package/include/std_msgs/Header.h
+++ b/roslibrust_genmsg/test_package/include/std_msgs/Header.h
@@ -50,7 +50,7 @@ struct Header_
     
     
       
-        typedef ::std::string _frame_id_type;
+        typedef std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>> _frame_id_type;
     _frame_id_type frame_id;
 
   
@@ -214,7 +214,7 @@ struct Printer< ::std_msgs::Header_<ContainerAllocator>>
     s << indent << "frame_id: ";
     s << std::endl;
     
-    Printer< ::std::string>::stream(s, indent + "  ", v.frame_id);
+    Printer< std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>>>::stream(s, indent + "  ", v.frame_id);
     
   }
 };

--- a/roslibrust_genmsg/test_package/include/std_srvs/TriggerResponse.h
+++ b/roslibrust_genmsg/test_package/include/std_srvs/TriggerResponse.h
@@ -43,7 +43,7 @@ struct TriggerResponse_
     
     
       
-        typedef ::std::string _message_type;
+        typedef std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>> _message_type;
     _message_type message;
 
   
@@ -200,7 +200,7 @@ struct Printer< ::std_srvs::TriggerResponse_<ContainerAllocator>>
     s << indent << "message: ";
     s << std::endl;
     
-    Printer< ::std::string>::stream(s, indent + "  ", v.message);
+    Printer< std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>>>::stream(s, indent + "  ", v.message);
     
   }
 };


### PR DESCRIPTION
* Updated the mapping for string type in C++ to exactly what ROS uses in order to allow overriding the allocator.
* Added forgotten `uint64` to list of ROS types.