### PR TITLE
Add the ability to pass custom minijinja filters to the code generator

### DIFF
--- a/roslibrust_genmsg/src/helpers.rs
+++ b/roslibrust_genmsg/src/helpers.rs
@@ -5,22 +5,24 @@ use std::collections::HashMap;
 pub fn prepare_environment<'a>(
     message_template: &'a str,
     service_template: &'a str,
-    typename_conversion_mapping: HashMap<String, String>,
+    typename_conversion_mapping: Option<HashMap<String, String>>,
 ) -> Environment<'a> {
     let mut env = Environment::new();
     env.add_function("has_header", has_header);
     env.add_function("is_fixed_length", is_fixed_length);
     env.add_function("is_intrinsic_type", is_intrinsic_type);
     env.add_function("is_array", is_array_type);
-    env.add_filter("typename_conversion", move |v: Value| {
-        let value = serde_json::to_value(v).unwrap();
-        let ros_type = value.as_str().unwrap();
-        let typename = match typename_conversion_mapping.get(ros_type) {
-            Some(native_type) => native_type.clone(),
-            None => ros_type.to_string(),
-        };
-        Value::from_serializable(&typename)
-    });
+    if let Some(map) = typename_conversion_mapping {
+        env.add_filter("typename_conversion", move |v: Value| {
+            let value = serde_json::to_value(v).unwrap();
+            let ros_type = value.as_str().unwrap();
+            let typename = match map.get(ros_type) {
+                Some(native_type) => native_type.clone(),
+                None => ros_type.to_string(),
+            };
+            Value::from_serializable(&typename)
+        });
+    }
     env.add_template("message", message_template).unwrap();
     env.add_template("service", service_template).unwrap();
     env

--- a/roslibrust_genmsg/src/lib.rs
+++ b/roslibrust_genmsg/src/lib.rs
@@ -39,45 +39,53 @@ impl From<&Package> for IncludedNamespace {
 }
 
 pub struct MessageGenOutput {
+    /// The short name of the ROS message
     pub message_name: String,
+    /// The package namespace
     pub package_name: String,
+    /// The generated source for the message
     pub message_source: String,
 }
 
 pub struct ServiceGenOutput {
+    /// The short name of the ROS service
     pub service_name: String,
+    /// The package namespace
     pub package_name: String,
+    /// The generated source for the request structure
     pub request_source: String,
+    /// The generated source for the response structure
     pub response_source: String,
+    /// The generated source for the service structure
     pub service_source: String,
 }
 
+type Filter = dyn Fn(minijinja::value::Value) -> minijinja::value::Value + Send + Sync;
+
+/// A builder to customize the generation of code from ROS message and service
+/// definitions.
 pub struct CodeGeneratorBuilder<'a> {
     msg_paths: Vec<PathBuf>,
     msg_template: &'a str,
     srv_template: Option<&'a str>,
-    typename_conversion_mapping: HashMap<String, String>,
-    filters: Vec<(
-        String,
-        Box<dyn Fn(minijinja::value::Value) -> minijinja::value::Value + Send + Sync>,
-    )>,
+    typename_conversion_mapping: Option<HashMap<String, String>>,
+    filters: Vec<(String, Box<Filter>)>,
 }
 
 impl<'a> CodeGeneratorBuilder<'a> {
-    pub fn new<P: AsRef<Path>>(
-        search_paths: &[P],
-        msg_template: &'a str,
-        typename_conversion_mapping: HashMap<String, String>,
-    ) -> Self {
+    /// Create the builder with the minimum required dependencies of code generation
+    pub fn new<P: AsRef<Path>>(search_paths: &[P], msg_template: &'a str) -> Self {
         Self {
             msg_paths: search_paths.iter().map(|p| p.as_ref().to_owned()).collect(),
             msg_template,
             srv_template: None,
-            typename_conversion_mapping,
+            typename_conversion_mapping: None,
             filters: vec![],
         }
     }
 
+    /// Performs discovery of ROS messages, services, and actions, resolves their
+    /// dependency graph and builds a `CodeGenerator`.
     pub fn build(self) -> std::io::Result<CodeGenerator<'a>> {
         let (messages, services) = roslibrust_codegen::find_and_parse_ros_messages(self.msg_paths)?;
         let (messages, services) =
@@ -100,11 +108,20 @@ impl<'a> CodeGeneratorBuilder<'a> {
         })
     }
 
+    /// Add a service template for generating service sources.
     pub fn service_template(mut self, srv_template: &'a str) -> Self {
         self.srv_template = Some(srv_template);
         self
     }
 
+    /// Add a map of type names from ROS types to native types using the filter
+    /// `typename_conversion`.
+    pub fn add_type_mapping(mut self, map: HashMap<String, String>) -> Self {
+        self.typename_conversion_mapping = Some(map);
+        self
+    }
+
+    /// Add a custom filter which can be used by the message and service templates.
     pub fn add_filter<F>(mut self, name: &str, filter: F) -> Self
     where
         F: Fn(minijinja::value::Value) -> minijinja::value::Value + Send + Sync + 'static,
@@ -121,6 +138,7 @@ pub struct CodeGenerator<'a> {
 }
 
 impl<'a> CodeGenerator<'a> {
+    /// Generate source for all ROS messages (and actions)
     pub fn generate_messages(&self) -> Result<Vec<MessageGenOutput>, minijinja::Error> {
         self.messages
             .iter()
@@ -138,6 +156,7 @@ impl<'a> CodeGenerator<'a> {
             .collect::<Result<Vec<_>, _>>()
     }
 
+    /// Generate source for all ROS services
     pub fn generate_services(&self) -> Result<Vec<ServiceGenOutput>, minijinja::Error> {
         self.services
             .iter()
@@ -166,14 +185,12 @@ impl<'a> CodeGenerator<'a> {
     }
 }
 
+/// Create a code generator for C++ headers.
 pub fn make_cpp_generator<P: AsRef<Path>>(search_paths: &[P]) -> std::io::Result<CodeGenerator> {
-    CodeGeneratorBuilder::new(
-        search_paths,
-        cpp::MESSAGE_HEADER_TMPL,
-        ROS_TYPE_TO_CPP_TYPE_MAP.clone(),
-    )
-    .service_template(cpp::SERVICE_HEADER_TMPL)
-    .build()
+    CodeGeneratorBuilder::new(search_paths, cpp::MESSAGE_HEADER_TMPL)
+        .add_type_mapping(ROS_TYPE_TO_CPP_TYPE_MAP.clone())
+        .service_template(cpp::SERVICE_HEADER_TMPL)
+        .build()
 }
 
 fn fill_message_template(

--- a/roslibrust_genmsg/src/main.rs
+++ b/roslibrust_genmsg/src/main.rs
@@ -249,7 +249,6 @@ mod test {
                 {%- endfor %}        
             }
             "#,
-            std::collections::HashMap::new(),
         )
         .add_filter("map_type", move |v| {
             let value = serde_json::to_value(v).unwrap();

--- a/roslibrust_genmsg/src/main.rs
+++ b/roslibrust_genmsg/src/main.rs
@@ -245,12 +245,21 @@ mod test {
             r#"
             pub struct {{ spec.short_name }} {
                 {% for field in spec.fields %}
-                {{ field.name }}: {{ field.field_type|typename_conversion }},
+                {{ field.name }}: {{ field.field_type|map_type }},
                 {%- endfor %}        
             }
             "#,
-            mapping,
+            std::collections::HashMap::new(),
         )
+        .add_filter("map_type", move |v| {
+            let value = serde_json::to_value(v).unwrap();
+            let ros_type = value.as_str().unwrap();
+            let typename = match mapping.get(ros_type) {
+                Some(native_type) => native_type.clone(),
+                None => ros_type.to_string(),
+            };
+            typename.into()
+        })
         .build()
         .unwrap();
 


### PR DESCRIPTION
Figured out this API and it's pretty handy for some upcoming generation replacing some empy code with a ton of helpers.