### PR TITLE
Update parsing to support fixed-size arrays in ROS1

### DIFF
--- a/roslibrust_genmsg/assets/msg.h.j2
+++ b/roslibrust_genmsg/assets/msg.h.j2
@@ -198,7 +198,7 @@ struct HasHeader< ::{{ spec.package }}::{{ spec.short_name }}_<ContainerAllocato
 template<class ContainerAllocator>
 struct MD5Sum< ::{{ spec.package }}::{{ spec.short_name }}_<ContainerAllocator>>
 {
-  static const char* value()
+  static constexpr char const * value()
   {
     return "{{ spec.md5sum_first }}{{ spec.md5sum_second }}";
   }
@@ -211,7 +211,7 @@ struct MD5Sum< ::{{ spec.package }}::{{ spec.short_name }}_<ContainerAllocator>>
 template<class ContainerAllocator>
 struct DataType< ::{{ spec.package }}::{{ spec.short_name }}_<ContainerAllocator>>
 {
-  static const char* value()
+  static constexpr char const* value()
   {
     return "{{ spec.package }}/{{ spec.short_name }}";
   }
@@ -222,7 +222,7 @@ struct DataType< ::{{ spec.package }}::{{ spec.short_name }}_<ContainerAllocator
 template<class ContainerAllocator>
 struct Definition< ::{{ spec.package }}::{{ spec.short_name }}_<ContainerAllocator>>
 {
-  static const char* value()
+  static constexpr char const* value()
   {
     return "{{ spec.definition }}";
   }

--- a/roslibrust_genmsg/assets/msg.h.j2
+++ b/roslibrust_genmsg/assets/msg.h.j2
@@ -49,11 +49,17 @@ struct {{ spec.short_name }}_
        Trade-off here between repetition and ability to reason about what 
        code should be generated. 
     #}
-    {%- if is_array(field) %}
+    {%- if is_vector(field) %}
       {%- if is_intrinsic_type(field) %}
         typedef std::vector<{{ field.field_type|typename_conversion }}, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<{{ field.field_type|typename_conversion }}>> _{{ field.name }}_type;
       {%- else %}
         typedef std::vector<::{{ field.package }}::{{ field.field_type }}_<ContainerAllocator>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<::{{ field.package }}::{{ field.field_type }}_<ContainerAllocator>>> _{{ field.name }}_type;
+      {%- endif %}
+    {%- elif is_fixed_array(field) %}
+      {%- if is_intrinsic_type(field) %}
+        typedef boost::array<{{ field.field_type|typename_conversion }}, {{ field|fixed_size_array_size }}> _{{ field.name }}_type;
+      {%- else %}
+        typedef boost::array<::{{ field.package }}::{{ field.field_type }}_<ContainerAllocator>, {{ field|fixed_size_array_size }}> _{{ field.name }}_type;
       {%- endif %}
     {%- else %}
       {%- if is_intrinsic_type(field) %}
@@ -265,7 +271,7 @@ struct Printer< ::{{ spec.package }}::{{ spec.short_name }}_<ContainerAllocator>
   template<typename Stream> static void stream(Stream& s, const std::string& indent, const ::{{ spec.package }}::{{ spec.short_name }}_<ContainerAllocator>& v)
   {
     {%- for field in spec.fields %}
-    {%- if is_array(field) %}
+    {%- if is_vector(field) %}
     
     s << indent << "{{ field.name }}[]" << std::endl;
     for (size_t i = 0; i < v.{{ field.name }}.size(); ++i)

--- a/roslibrust_genmsg/regenerate-test-msgs.sh
+++ b/roslibrust_genmsg/regenerate-test-msgs.sh
@@ -38,6 +38,14 @@ cargo run --bin gencpp -- \
 --output roslibrust_genmsg/test_package/include/sensor_msgs
 
 cargo run --bin gencpp -- \
+--msg assets/ros1_common_interfaces/common_msgs/sensor_msgs/msg/CameraInfo.msg \
+--package sensor_msgs \
+-I std_msgs:assets/ros1_common_interfaces/std_msgs \
+-I geometry_msgs:assets/ros1_common_interfaces/common_msgs/geometry_msgs \
+-I sensor_msgs:assets/ros1_common_interfaces/common_msgs/sensor_msgs \
+--output roslibrust_genmsg/test_package/include/sensor_msgs
+
+cargo run --bin gencpp -- \
 --msg assets/ros1_common_interfaces/common_msgs/geometry_msgs/msg/Point32.msg \
 --package geometry_msgs \
 -I std_msgs:assets/ros1_common_interfaces/std_msgs \

--- a/roslibrust_genmsg/src/helpers.rs
+++ b/roslibrust_genmsg/src/helpers.rs
@@ -11,7 +11,7 @@ pub fn prepare_environment<'a>(
     env.add_function("has_header", has_header);
     env.add_function("is_fixed_length", is_fixed_length);
     env.add_function("is_intrinsic_type", is_intrinsic_type);
-    env.add_function("is_array", is_array_type);
+    env.add_function("is_vector", is_vector_type);
     env.add_function("is_fixed_array", is_fixed_size_array_type);
     env.add_filter("fixed_size_array_size", fixed_size_array_size);
     if let Some(map) = typename_conversion_mapping {
@@ -70,10 +70,10 @@ pub fn is_intrinsic_type(value: Value) -> bool {
     }
 }
 
-pub fn is_array_type(value: Value) -> bool {
-    if let Ok(value) = serde_json::to_value(value) {
-        if let Ok(field) = serde_json::from_value::<Field>(value) {
-            field.is_array_type()
+pub fn is_vector_type(value: Value) -> bool {
+    if let Ok(v) = serde_json::to_value(value.clone()) {
+        if let Ok(field) = serde_json::from_value::<Field>(v) {
+            field.is_vector_type()
         } else {
             false
         }

--- a/roslibrust_genmsg/src/helpers.rs
+++ b/roslibrust_genmsg/src/helpers.rs
@@ -12,6 +12,8 @@ pub fn prepare_environment<'a>(
     env.add_function("is_fixed_length", is_fixed_length);
     env.add_function("is_intrinsic_type", is_intrinsic_type);
     env.add_function("is_array", is_array_type);
+    env.add_function("is_fixed_array", is_fixed_size_array_type);
+    env.add_filter("fixed_size_array_size", fixed_size_array_size);
     if let Some(map) = typename_conversion_mapping {
         env.add_filter("typename_conversion", move |v: Value| {
             let value = serde_json::to_value(v).unwrap();
@@ -78,4 +80,29 @@ pub fn is_array_type(value: Value) -> bool {
     } else {
         false
     }
+}
+
+pub fn is_fixed_size_array_type(value: Value) -> bool {
+    if let Ok(value) = serde_json::to_value(value) {
+        if let Ok(field) = serde_json::from_value::<Field>(value) {
+            field.is_fixed_size_array_type()
+        } else {
+            false
+        }
+    } else {
+        false
+    }
+}
+
+pub fn fixed_size_array_size(value: Value) -> Value {
+    let fixed_size = if let Ok(value) = serde_json::to_value(value) {
+        if let Ok(field) = serde_json::from_value::<Field>(value) {
+            field.fixed_size_array_size()
+        } else {
+            0
+        }
+    } else {
+        0
+    };
+    Value::from_serializable(&fixed_size)
 }

--- a/roslibrust_genmsg/src/spec.rs
+++ b/roslibrust_genmsg/src/spec.rs
@@ -11,7 +11,7 @@ pub struct Field {
     pub name: String,
     pub field_type: String,
     pub package: Option<String>,
-    pub is_array_type: bool,
+    pub array_info: Option<Option<usize>>,
 }
 
 impl From<&FieldInfo> for Field {
@@ -20,7 +20,7 @@ impl From<&FieldInfo> for Field {
             name: value.field_name.clone(),
             field_type: value.field_type.field_type.clone(),
             package: value.field_type.package_name.clone(),
-            is_array_type: value.field_type.is_vec,
+            array_info: value.field_type.array_info,
         }
     }
 }
@@ -31,7 +31,19 @@ impl Field {
     }
 
     pub fn is_array_type(&self) -> bool {
-        self.is_array_type
+        self.array_info.is_some()
+    }
+
+    pub fn is_fixed_size_array_type(&self) -> bool {
+        matches!(self.array_info, Some(Some(_)))
+    }
+
+    pub fn fixed_size_array_size(&self) -> usize {
+        if let Some(Some(n)) = self.array_info {
+            n
+        } else {
+            0
+        }
     }
 }
 

--- a/roslibrust_genmsg/src/spec.rs
+++ b/roslibrust_genmsg/src/spec.rs
@@ -7,11 +7,18 @@ pub static ROS_TYPENAMES: &[&str] = &[
 ];
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
+pub enum ArrayInfo {
+    NotAnArray,
+    Vector,
+    Array(usize),
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct Field {
     pub name: String,
     pub field_type: String,
     pub package: Option<String>,
-    pub array_info: Option<Option<usize>>,
+    pub array_info: ArrayInfo,
 }
 
 impl From<&FieldInfo> for Field {
@@ -20,7 +27,11 @@ impl From<&FieldInfo> for Field {
             name: value.field_name.clone(),
             field_type: value.field_type.field_type.clone(),
             package: value.field_type.package_name.clone(),
-            array_info: value.field_type.array_info,
+            array_info: match value.field_type.array_info {
+                Some(Some(n)) => ArrayInfo::Array(n),
+                Some(None) => ArrayInfo::Vector,
+                None => ArrayInfo::NotAnArray,
+            },
         }
     }
 }
@@ -30,16 +41,16 @@ impl Field {
         ROS_TYPENAMES.contains(&self.field_type.as_str())
     }
 
-    pub fn is_array_type(&self) -> bool {
-        self.array_info.is_some()
+    pub fn is_vector_type(&self) -> bool {
+        matches!(self.array_info, ArrayInfo::Vector)
     }
 
     pub fn is_fixed_size_array_type(&self) -> bool {
-        matches!(self.array_info, Some(Some(_)))
+        matches!(self.array_info, ArrayInfo::Array(_))
     }
 
     pub fn fixed_size_array_size(&self) -> usize {
-        if let Some(Some(n)) = self.array_info {
+        if let ArrayInfo::Array(n) = self.array_info {
             n
         } else {
             0

--- a/roslibrust_genmsg/test_package/include/geometry_msgs/Point32.h
+++ b/roslibrust_genmsg/test_package/include/geometry_msgs/Point32.h
@@ -116,7 +116,7 @@ struct HasHeader< ::geometry_msgs::Point32_<ContainerAllocator> const>
 template<class ContainerAllocator>
 struct MD5Sum< ::geometry_msgs::Point32_<ContainerAllocator>>
 {
-  static const char* value()
+  static constexpr char const * value()
   {
     return "cc153912f1453b708d221682bc23d9ac";
   }
@@ -129,7 +129,7 @@ struct MD5Sum< ::geometry_msgs::Point32_<ContainerAllocator>>
 template<class ContainerAllocator>
 struct DataType< ::geometry_msgs::Point32_<ContainerAllocator>>
 {
-  static const char* value()
+  static constexpr char const* value()
   {
     return "geometry_msgs/Point32";
   }
@@ -140,7 +140,7 @@ struct DataType< ::geometry_msgs::Point32_<ContainerAllocator>>
 template<class ContainerAllocator>
 struct Definition< ::geometry_msgs::Point32_<ContainerAllocator>>
 {
-  static const char* value()
+  static constexpr char const* value()
   {
     return "";
   }

--- a/roslibrust_genmsg/test_package/include/geometry_msgs/Polygon.h
+++ b/roslibrust_genmsg/test_package/include/geometry_msgs/Polygon.h
@@ -27,7 +27,7 @@ struct Polygon_
     (void)_alloc;
   }
     
-        typedef std::vector<::geometry_msgs::Point32_<ContainerAllocator>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<::geometry_msgs::Point32_<ContainerAllocator>>> _points_type;
+        typedef ::geometry_msgs::Point32_<ContainerAllocator> _points_type;
     _points_type points;
 
   
@@ -169,15 +169,10 @@ struct Printer< ::geometry_msgs::Polygon_<ContainerAllocator>>
 {
   template<typename Stream> static void stream(Stream& s, const std::string& indent, const ::geometry_msgs::Polygon_<ContainerAllocator>& v)
   {
-    
-    s << indent << "points[]" << std::endl;
-    for (size_t i = 0; i < v.points.size(); ++i)
-    {
-      s << indent << "  points[" << i << "]: ";
-      s << std::endl;
-      s << indent;
-      Printer<::geometry_msgs::Point32>::stream(s, indent + "    ", v.points[i]);
-    }
+
+    s << indent << "points: ";
+    s << std::endl;
+    Printer< ::geometry_msgs::Point32_<ContainerAllocator>>::stream(s, indent + "  ", v.points);
   }
 };
 

--- a/roslibrust_genmsg/test_package/include/geometry_msgs/Polygon.h
+++ b/roslibrust_genmsg/test_package/include/geometry_msgs/Polygon.h
@@ -27,7 +27,7 @@ struct Polygon_
     (void)_alloc;
   }
     
-        typedef ::geometry_msgs::Point32_<ContainerAllocator> _points_type;
+        typedef std::vector<::geometry_msgs::Point32_<ContainerAllocator>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<::geometry_msgs::Point32_<ContainerAllocator>>> _points_type;
     _points_type points;
 
   
@@ -169,10 +169,15 @@ struct Printer< ::geometry_msgs::Polygon_<ContainerAllocator>>
 {
   template<typename Stream> static void stream(Stream& s, const std::string& indent, const ::geometry_msgs::Polygon_<ContainerAllocator>& v)
   {
-
-    s << indent << "points: ";
-    s << std::endl;
-    Printer< ::geometry_msgs::Point32_<ContainerAllocator>>::stream(s, indent + "  ", v.points);
+    
+    s << indent << "points[]" << std::endl;
+    for (size_t i = 0; i < v.points.size(); ++i)
+    {
+      s << indent << "  points[" << i << "]: ";
+      s << std::endl;
+      s << indent;
+      Printer<::geometry_msgs::Point32>::stream(s, indent + "    ", v.points[i]);
+    }
   }
 };
 

--- a/roslibrust_genmsg/test_package/include/geometry_msgs/Polygon.h
+++ b/roslibrust_genmsg/test_package/include/geometry_msgs/Polygon.h
@@ -105,7 +105,7 @@ struct HasHeader< ::geometry_msgs::Polygon_<ContainerAllocator> const>
 template<class ContainerAllocator>
 struct MD5Sum< ::geometry_msgs::Polygon_<ContainerAllocator>>
 {
-  static const char* value()
+  static constexpr char const * value()
   {
     return "cd60a26494a087f577976f0329fa120e";
   }
@@ -118,7 +118,7 @@ struct MD5Sum< ::geometry_msgs::Polygon_<ContainerAllocator>>
 template<class ContainerAllocator>
 struct DataType< ::geometry_msgs::Polygon_<ContainerAllocator>>
 {
-  static const char* value()
+  static constexpr char const* value()
   {
     return "geometry_msgs/Polygon";
   }
@@ -129,7 +129,7 @@ struct DataType< ::geometry_msgs::Polygon_<ContainerAllocator>>
 template<class ContainerAllocator>
 struct Definition< ::geometry_msgs::Polygon_<ContainerAllocator>>
 {
-  static const char* value()
+  static constexpr char const* value()
   {
     return "";
   }

--- a/roslibrust_genmsg/test_package/include/sensor_msgs/BatteryState.h
+++ b/roslibrust_genmsg/test_package/include/sensor_msgs/BatteryState.h
@@ -218,7 +218,7 @@ struct HasHeader< ::sensor_msgs::BatteryState_<ContainerAllocator> const>
 template<class ContainerAllocator>
 struct MD5Sum< ::sensor_msgs::BatteryState_<ContainerAllocator>>
 {
-  static const char* value()
+  static constexpr char const * value()
   {
     return "4ddae7f048e32fda22cac764685e3974";
   }
@@ -231,7 +231,7 @@ struct MD5Sum< ::sensor_msgs::BatteryState_<ContainerAllocator>>
 template<class ContainerAllocator>
 struct DataType< ::sensor_msgs::BatteryState_<ContainerAllocator>>
 {
-  static const char* value()
+  static constexpr char const* value()
   {
     return "sensor_msgs/BatteryState";
   }
@@ -242,7 +242,7 @@ struct DataType< ::sensor_msgs::BatteryState_<ContainerAllocator>>
 template<class ContainerAllocator>
 struct Definition< ::sensor_msgs::BatteryState_<ContainerAllocator>>
 {
-  static const char* value()
+  static constexpr char const* value()
   {
     return "";
   }

--- a/roslibrust_genmsg/test_package/include/sensor_msgs/BatteryState.h
+++ b/roslibrust_genmsg/test_package/include/sensor_msgs/BatteryState.h
@@ -93,10 +93,10 @@ struct BatteryState_
         typedef uint8_t _present_type;
     _present_type present;
     
-        typedef float _cell_voltage_type;
+        typedef std::vector<float, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<float>> _cell_voltage_type;
     _cell_voltage_type cell_voltage;
     
-        typedef float _cell_temperature_type;
+        typedef std::vector<float, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<float>> _cell_temperature_type;
     _cell_temperature_type cell_temperature;
     
         typedef std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>> _location_type;
@@ -334,12 +334,20 @@ struct Printer< ::sensor_msgs::BatteryState_<ContainerAllocator>>
 
     s << indent << "present: ";
     Printer< uint8_t>::stream(s, indent + "  ", v.present);
-
-    s << indent << "cell_voltage: ";
-    Printer< float>::stream(s, indent + "  ", v.cell_voltage);
-
-    s << indent << "cell_temperature: ";
-    Printer< float>::stream(s, indent + "  ", v.cell_temperature);
+    
+    s << indent << "cell_voltage[]" << std::endl;
+    for (size_t i = 0; i < v.cell_voltage.size(); ++i)
+    {
+      s << indent << "  cell_voltage[" << i << "]: ";
+      Printer<float>::stream(s, indent + "  ", v.cell_voltage[i]);
+    }
+    
+    s << indent << "cell_temperature[]" << std::endl;
+    for (size_t i = 0; i < v.cell_temperature.size(); ++i)
+    {
+      s << indent << "  cell_temperature[" << i << "]: ";
+      Printer<float>::stream(s, indent + "  ", v.cell_temperature[i]);
+    }
 
     s << indent << "location: ";
     Printer< std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>>>::stream(s, indent + "  ", v.location);

--- a/roslibrust_genmsg/test_package/include/sensor_msgs/BatteryState.h
+++ b/roslibrust_genmsg/test_package/include/sensor_msgs/BatteryState.h
@@ -93,10 +93,10 @@ struct BatteryState_
         typedef uint8_t _present_type;
     _present_type present;
     
-        typedef std::vector<float, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<float>> _cell_voltage_type;
+        typedef float _cell_voltage_type;
     _cell_voltage_type cell_voltage;
     
-        typedef std::vector<float, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<float>> _cell_temperature_type;
+        typedef float _cell_temperature_type;
     _cell_temperature_type cell_temperature;
     
         typedef std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>> _location_type;
@@ -334,20 +334,12 @@ struct Printer< ::sensor_msgs::BatteryState_<ContainerAllocator>>
 
     s << indent << "present: ";
     Printer< uint8_t>::stream(s, indent + "  ", v.present);
-    
-    s << indent << "cell_voltage[]" << std::endl;
-    for (size_t i = 0; i < v.cell_voltage.size(); ++i)
-    {
-      s << indent << "  cell_voltage[" << i << "]: ";
-      Printer<float>::stream(s, indent + "  ", v.cell_voltage[i]);
-    }
-    
-    s << indent << "cell_temperature[]" << std::endl;
-    for (size_t i = 0; i < v.cell_temperature.size(); ++i)
-    {
-      s << indent << "  cell_temperature[" << i << "]: ";
-      Printer<float>::stream(s, indent + "  ", v.cell_temperature[i]);
-    }
+
+    s << indent << "cell_voltage: ";
+    Printer< float>::stream(s, indent + "  ", v.cell_voltage);
+
+    s << indent << "cell_temperature: ";
+    Printer< float>::stream(s, indent + "  ", v.cell_temperature);
 
     s << indent << "location: ";
     Printer< std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>>>::stream(s, indent + "  ", v.location);

--- a/roslibrust_genmsg/test_package/include/sensor_msgs/CameraInfo.h
+++ b/roslibrust_genmsg/test_package/include/sensor_msgs/CameraInfo.h
@@ -166,7 +166,7 @@ struct HasHeader< ::sensor_msgs::CameraInfo_<ContainerAllocator> const>
 template<class ContainerAllocator>
 struct MD5Sum< ::sensor_msgs::CameraInfo_<ContainerAllocator>>
 {
-  static const char* value()
+  static constexpr char const * value()
   {
     return "c9a58c1b0b154e0e6da7578cb991d214";
   }
@@ -179,7 +179,7 @@ struct MD5Sum< ::sensor_msgs::CameraInfo_<ContainerAllocator>>
 template<class ContainerAllocator>
 struct DataType< ::sensor_msgs::CameraInfo_<ContainerAllocator>>
 {
-  static const char* value()
+  static constexpr char const* value()
   {
     return "sensor_msgs/CameraInfo";
   }
@@ -190,7 +190,7 @@ struct DataType< ::sensor_msgs::CameraInfo_<ContainerAllocator>>
 template<class ContainerAllocator>
 struct Definition< ::sensor_msgs::CameraInfo_<ContainerAllocator>>
 {
-  static const char* value()
+  static constexpr char const* value()
   {
     return "";
   }

--- a/roslibrust_genmsg/test_package/include/sensor_msgs/CameraInfo.h
+++ b/roslibrust_genmsg/test_package/include/sensor_msgs/CameraInfo.h
@@ -60,16 +60,16 @@ struct CameraInfo_
         typedef std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>> _distortion_model_type;
     _distortion_model_type distortion_model;
     
-        typedef double _D_type;
+        typedef std::vector<double, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<double>> _D_type;
     _D_type D;
     
-        typedef std::vector<double, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<double>> _K_type;
+        typedef boost::array<double, 9> _K_type;
     _K_type K;
     
-        typedef std::vector<double, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<double>> _R_type;
+        typedef boost::array<double, 9> _R_type;
     _R_type R;
     
-        typedef std::vector<double, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<double>> _P_type;
+        typedef boost::array<double, 12> _P_type;
     _P_type P;
     
         typedef uint32_t _binning_x_type;
@@ -253,30 +253,22 @@ struct Printer< ::sensor_msgs::CameraInfo_<ContainerAllocator>>
 
     s << indent << "distortion_model: ";
     Printer< std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>>>::stream(s, indent + "  ", v.distortion_model);
+    
+    s << indent << "D[]" << std::endl;
+    for (size_t i = 0; i < v.D.size(); ++i)
+    {
+      s << indent << "  D[" << i << "]: ";
+      Printer<double>::stream(s, indent + "  ", v.D[i]);
+    }
 
-    s << indent << "D: ";
-    Printer< double>::stream(s, indent + "  ", v.D);
-    
-    s << indent << "K[]" << std::endl;
-    for (size_t i = 0; i < v.K.size(); ++i)
-    {
-      s << indent << "  K[" << i << "]: ";
-      Printer<double>::stream(s, indent + "  ", v.K[i]);
-    }
-    
-    s << indent << "R[]" << std::endl;
-    for (size_t i = 0; i < v.R.size(); ++i)
-    {
-      s << indent << "  R[" << i << "]: ";
-      Printer<double>::stream(s, indent + "  ", v.R[i]);
-    }
-    
-    s << indent << "P[]" << std::endl;
-    for (size_t i = 0; i < v.P.size(); ++i)
-    {
-      s << indent << "  P[" << i << "]: ";
-      Printer<double>::stream(s, indent + "  ", v.P[i]);
-    }
+    s << indent << "K: ";
+    Printer< double>::stream(s, indent + "  ", v.K);
+
+    s << indent << "R: ";
+    Printer< double>::stream(s, indent + "  ", v.R);
+
+    s << indent << "P: ";
+    Printer< double>::stream(s, indent + "  ", v.P);
 
     s << indent << "binning_x: ";
     Printer< uint32_t>::stream(s, indent + "  ", v.binning_x);

--- a/roslibrust_genmsg/test_package/include/sensor_msgs/CameraInfo.h
+++ b/roslibrust_genmsg/test_package/include/sensor_msgs/CameraInfo.h
@@ -60,7 +60,7 @@ struct CameraInfo_
         typedef std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>> _distortion_model_type;
     _distortion_model_type distortion_model;
     
-        typedef std::vector<double, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<double>> _D_type;
+        typedef double _D_type;
     _D_type D;
     
         typedef std::vector<double, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<double>> _K_type;
@@ -168,12 +168,12 @@ struct MD5Sum< ::sensor_msgs::CameraInfo_<ContainerAllocator>>
 {
   static const char* value()
   {
-    return "0b90a09f7d964437a2b7ac1f61cd712f";
+    return "c9a58c1b0b154e0e6da7578cb991d214";
   }
 
   static const char* value(const ::sensor_msgs::CameraInfo_<ContainerAllocator>&) { return value(); }
-  static const uint64_t static_value1 = 0x0b90a09f7d964437ULL;
-  static const uint64_t static_value2 = 0xa2b7ac1f61cd712fULL;
+  static const uint64_t static_value1 = 0xc9a58c1b0b154e0eULL;
+  static const uint64_t static_value2 = 0x6da7578cb991d214ULL;
 };
 
 template<class ContainerAllocator>
@@ -253,13 +253,9 @@ struct Printer< ::sensor_msgs::CameraInfo_<ContainerAllocator>>
 
     s << indent << "distortion_model: ";
     Printer< std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>>>::stream(s, indent + "  ", v.distortion_model);
-    
-    s << indent << "D[]" << std::endl;
-    for (size_t i = 0; i < v.D.size(); ++i)
-    {
-      s << indent << "  D[" << i << "]: ";
-      Printer<double>::stream(s, indent + "  ", v.D[i]);
-    }
+
+    s << indent << "D: ";
+    Printer< double>::stream(s, indent + "  ", v.D);
     
     s << indent << "K[]" << std::endl;
     for (size_t i = 0; i < v.K.size(); ++i)

--- a/roslibrust_genmsg/test_package/include/sensor_msgs/CameraInfo.h
+++ b/roslibrust_genmsg/test_package/include/sensor_msgs/CameraInfo.h
@@ -1,0 +1,300 @@
+#ifndef SENSOR_MSGS_MESSAGE_CAMERAINFO
+#define SENSOR_MSGS_MESSAGE_CAMERAINFO
+
+#include <string>
+#include <vector>
+#include <memory>
+
+#include <ros/types.h>
+#include <ros/serialization.h>
+#include <ros/builtin_message_traits.h>
+#include <ros/message_operations.h>
+
+#include <std_msgs/Header.h>
+#include <sensor_msgs/RegionOfInterest.h>
+
+namespace sensor_msgs {
+
+template <class ContainerAllocator>
+struct CameraInfo_
+{
+  typedef CameraInfo_<ContainerAllocator> Type;
+  CameraInfo_()
+    : header()
+    , height()
+    , width()
+    , distortion_model()
+    , D()
+    , K()
+    , R()
+    , P()
+    , binning_x()
+    , binning_y()
+    , roi() {
+  }
+
+  CameraInfo_(const ContainerAllocator& _alloc)
+    : header(_alloc)
+    , height(_alloc)
+    , width(_alloc)
+    , distortion_model(_alloc)
+    , D(_alloc)
+    , K(_alloc)
+    , R(_alloc)
+    , P(_alloc)
+    , binning_x(_alloc)
+    , binning_y(_alloc)
+    , roi(_alloc) {
+    (void)_alloc;
+  }
+    
+        typedef ::std_msgs::Header_<ContainerAllocator> _header_type;
+    _header_type header;
+    
+        typedef uint32_t _height_type;
+    _height_type height;
+    
+        typedef uint32_t _width_type;
+    _width_type width;
+    
+        typedef std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>> _distortion_model_type;
+    _distortion_model_type distortion_model;
+    
+        typedef std::vector<double, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<double>> _D_type;
+    _D_type D;
+    
+        typedef std::vector<double, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<double>> _K_type;
+    _K_type K;
+    
+        typedef std::vector<double, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<double>> _R_type;
+    _R_type R;
+    
+        typedef std::vector<double, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<double>> _P_type;
+    _P_type P;
+    
+        typedef uint32_t _binning_x_type;
+    _binning_x_type binning_x;
+    
+        typedef uint32_t _binning_y_type;
+    _binning_y_type binning_y;
+    
+        typedef ::sensor_msgs::RegionOfInterest_<ContainerAllocator> _roi_type;
+    _roi_type roi;
+
+  
+
+  typedef boost::shared_ptr< ::sensor_msgs::CameraInfo_<ContainerAllocator>> Ptr;
+  typedef boost::shared_ptr< ::sensor_msgs::CameraInfo_<ContainerAllocator> const> ConstPtr;
+
+}; // struct CameraInfo_
+
+typedef ::sensor_msgs::CameraInfo_<std::allocator<void>> CameraInfo;
+
+typedef boost::shared_ptr< ::sensor_msgs::CameraInfo> CameraInfoPtr;
+typedef boost::shared_ptr< ::sensor_msgs::CameraInfo const> CameraInfoConstPtr;
+
+// constants requiring out of line definition
+
+template<typename ContainerAllocator>
+std::ostream& operator<<(std::ostream& s, const ::sensor_msgs::CameraInfo_<ContainerAllocator> & v)
+{
+ros::message_operations::Printer< ::sensor_msgs::CameraInfo_<ContainerAllocator> >::stream(s, "", v);
+return s;
+}
+
+template<typename ContainerAllocator1, typename ContainerAllocator2>
+bool operator==(const ::sensor_msgs::CameraInfo_<ContainerAllocator1> & lhs, const ::sensor_msgs::CameraInfo_<ContainerAllocator2> & rhs)
+{
+  return
+    lhs.header == rhs.header &&
+    lhs.height == rhs.height &&
+    lhs.width == rhs.width &&
+    lhs.distortion_model == rhs.distortion_model &&
+    lhs.D == rhs.D &&
+    lhs.K == rhs.K &&
+    lhs.R == rhs.R &&
+    lhs.P == rhs.P &&
+    lhs.binning_x == rhs.binning_x &&
+    lhs.binning_y == rhs.binning_y &&
+    lhs.roi == rhs.roi &&
+    true;
+}
+
+template<typename ContainerAllocator1, typename ContainerAllocator2>
+bool operator!=(const ::sensor_msgs::CameraInfo_<ContainerAllocator1> & lhs, const ::sensor_msgs::CameraInfo_<ContainerAllocator2> & rhs)
+{
+  return !(lhs == rhs);
+}
+
+
+} // namespace sensor_msgs
+
+namespace ros
+{
+namespace message_traits
+{
+template <class ContainerAllocator>
+struct IsMessage< ::sensor_msgs::CameraInfo_<ContainerAllocator>>
+  : TrueType
+  { };
+
+template <class ContainerAllocator>
+struct IsMessage< ::sensor_msgs::CameraInfo_<ContainerAllocator> const>
+  : TrueType
+  { };
+
+template <class ContainerAllocator>
+struct IsFixedSize< ::sensor_msgs::CameraInfo_<ContainerAllocator>>
+  : FalseType
+    { };
+
+template <class ContainerAllocator>
+struct IsFixedSize< ::sensor_msgs::CameraInfo_<ContainerAllocator> const>
+  : FalseType
+    { };
+
+template <class ContainerAllocator>
+struct HasHeader< ::sensor_msgs::CameraInfo_<ContainerAllocator>>
+  : TrueType
+    { };
+
+template <class ContainerAllocator>
+struct HasHeader< ::sensor_msgs::CameraInfo_<ContainerAllocator> const>
+  : TrueType
+    { };
+
+template<class ContainerAllocator>
+struct MD5Sum< ::sensor_msgs::CameraInfo_<ContainerAllocator>>
+{
+  static const char* value()
+  {
+    return "0b90a09f7d964437a2b7ac1f61cd712f";
+  }
+
+  static const char* value(const ::sensor_msgs::CameraInfo_<ContainerAllocator>&) { return value(); }
+  static const uint64_t static_value1 = 0x0b90a09f7d964437ULL;
+  static const uint64_t static_value2 = 0xa2b7ac1f61cd712fULL;
+};
+
+template<class ContainerAllocator>
+struct DataType< ::sensor_msgs::CameraInfo_<ContainerAllocator>>
+{
+  static const char* value()
+  {
+    return "sensor_msgs/CameraInfo";
+  }
+
+  static const char* value(const ::sensor_msgs::CameraInfo_<ContainerAllocator>&) { return value(); }
+};
+
+template<class ContainerAllocator>
+struct Definition< ::sensor_msgs::CameraInfo_<ContainerAllocator>>
+{
+  static const char* value()
+  {
+    return "";
+  }
+
+  static const char* value(const ::sensor_msgs::CameraInfo_<ContainerAllocator>&) { return value(); }
+};
+
+} // namespace message_traits
+} // namespace ros
+
+namespace ros
+{
+namespace serialization
+{
+
+template<class ContainerAllocator>
+struct Serializer< ::sensor_msgs::CameraInfo_<ContainerAllocator>>
+{
+  template<typename Stream, typename T> inline static void allInOne(Stream& stream, T m)
+  {
+    stream.next(m.header);
+    stream.next(m.height);
+    stream.next(m.width);
+    stream.next(m.distortion_model);
+    stream.next(m.D);
+    stream.next(m.K);
+    stream.next(m.R);
+    stream.next(m.P);
+    stream.next(m.binning_x);
+    stream.next(m.binning_y);
+    stream.next(m.roi);
+  }
+
+  ROS_DECLARE_ALLINONE_SERIALIZER
+}; // struct CameraInfo_
+
+} // namespace serialization
+} // namespace ros
+
+namespace ros
+{
+namespace message_operations
+{
+
+template<class ContainerAllocator>
+struct Printer< ::sensor_msgs::CameraInfo_<ContainerAllocator>>
+{
+  template<typename Stream> static void stream(Stream& s, const std::string& indent, const ::sensor_msgs::CameraInfo_<ContainerAllocator>& v)
+  {
+
+    s << indent << "header: ";
+    s << std::endl;
+    Printer< ::std_msgs::Header_<ContainerAllocator>>::stream(s, indent + "  ", v.header);
+
+    s << indent << "height: ";
+    Printer< uint32_t>::stream(s, indent + "  ", v.height);
+
+    s << indent << "width: ";
+    Printer< uint32_t>::stream(s, indent + "  ", v.width);
+
+    s << indent << "distortion_model: ";
+    Printer< std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>>>::stream(s, indent + "  ", v.distortion_model);
+    
+    s << indent << "D[]" << std::endl;
+    for (size_t i = 0; i < v.D.size(); ++i)
+    {
+      s << indent << "  D[" << i << "]: ";
+      Printer<double>::stream(s, indent + "  ", v.D[i]);
+    }
+    
+    s << indent << "K[]" << std::endl;
+    for (size_t i = 0; i < v.K.size(); ++i)
+    {
+      s << indent << "  K[" << i << "]: ";
+      Printer<double>::stream(s, indent + "  ", v.K[i]);
+    }
+    
+    s << indent << "R[]" << std::endl;
+    for (size_t i = 0; i < v.R.size(); ++i)
+    {
+      s << indent << "  R[" << i << "]: ";
+      Printer<double>::stream(s, indent + "  ", v.R[i]);
+    }
+    
+    s << indent << "P[]" << std::endl;
+    for (size_t i = 0; i < v.P.size(); ++i)
+    {
+      s << indent << "  P[" << i << "]: ";
+      Printer<double>::stream(s, indent + "  ", v.P[i]);
+    }
+
+    s << indent << "binning_x: ";
+    Printer< uint32_t>::stream(s, indent + "  ", v.binning_x);
+
+    s << indent << "binning_y: ";
+    Printer< uint32_t>::stream(s, indent + "  ", v.binning_y);
+
+    s << indent << "roi: ";
+    s << std::endl;
+    Printer< ::sensor_msgs::RegionOfInterest_<ContainerAllocator>>::stream(s, indent + "  ", v.roi);
+  }
+};
+
+} // namespace message_operations
+} // namespace ros
+
+#endif // SENSOR_MSGS_MESSAGE_CAMERAINFO

--- a/roslibrust_genmsg/test_package/include/std_msgs/Char.h
+++ b/roslibrust_genmsg/test_package/include/std_msgs/Char.h
@@ -104,7 +104,7 @@ struct HasHeader< ::std_msgs::Char_<ContainerAllocator> const>
 template<class ContainerAllocator>
 struct MD5Sum< ::std_msgs::Char_<ContainerAllocator>>
 {
-  static const char* value()
+  static constexpr char const * value()
   {
     return "1bf77f25acecdedba0e224b162199717";
   }
@@ -117,7 +117,7 @@ struct MD5Sum< ::std_msgs::Char_<ContainerAllocator>>
 template<class ContainerAllocator>
 struct DataType< ::std_msgs::Char_<ContainerAllocator>>
 {
-  static const char* value()
+  static constexpr char const* value()
   {
     return "std_msgs/Char";
   }
@@ -128,7 +128,7 @@ struct DataType< ::std_msgs::Char_<ContainerAllocator>>
 template<class ContainerAllocator>
 struct Definition< ::std_msgs::Char_<ContainerAllocator>>
 {
-  static const char* value()
+  static constexpr char const* value()
   {
     return "";
   }

--- a/roslibrust_genmsg/test_package/include/std_msgs/Header.h
+++ b/roslibrust_genmsg/test_package/include/std_msgs/Header.h
@@ -116,7 +116,7 @@ struct HasHeader< ::std_msgs::Header_<ContainerAllocator> const>
 template<class ContainerAllocator>
 struct MD5Sum< ::std_msgs::Header_<ContainerAllocator>>
 {
-  static const char* value()
+  static constexpr char const * value()
   {
     return "2176decaecbce78abc3b96ef049fabed";
   }
@@ -129,7 +129,7 @@ struct MD5Sum< ::std_msgs::Header_<ContainerAllocator>>
 template<class ContainerAllocator>
 struct DataType< ::std_msgs::Header_<ContainerAllocator>>
 {
-  static const char* value()
+  static constexpr char const* value()
   {
     return "std_msgs/Header";
   }
@@ -140,7 +140,7 @@ struct DataType< ::std_msgs::Header_<ContainerAllocator>>
 template<class ContainerAllocator>
 struct Definition< ::std_msgs::Header_<ContainerAllocator>>
 {
-  static const char* value()
+  static constexpr char const* value()
   {
     return "";
   }

--- a/roslibrust_genmsg/test_package/include/std_srvs/TriggerRequest.h
+++ b/roslibrust_genmsg/test_package/include/std_srvs/TriggerRequest.h
@@ -100,7 +100,7 @@ struct HasHeader< ::std_srvs::TriggerRequest_<ContainerAllocator> const>
 template<class ContainerAllocator>
 struct MD5Sum< ::std_srvs::TriggerRequest_<ContainerAllocator>>
 {
-  static const char* value()
+  static constexpr char const * value()
   {
     return "d41d8cd98f00b204e9800998ecf8427e";
   }
@@ -113,7 +113,7 @@ struct MD5Sum< ::std_srvs::TriggerRequest_<ContainerAllocator>>
 template<class ContainerAllocator>
 struct DataType< ::std_srvs::TriggerRequest_<ContainerAllocator>>
 {
-  static const char* value()
+  static constexpr char const* value()
   {
     return "std_srvs/TriggerRequest";
   }
@@ -124,7 +124,7 @@ struct DataType< ::std_srvs::TriggerRequest_<ContainerAllocator>>
 template<class ContainerAllocator>
 struct Definition< ::std_srvs::TriggerRequest_<ContainerAllocator>>
 {
-  static const char* value()
+  static constexpr char const* value()
   {
     return "";
   }

--- a/roslibrust_genmsg/test_package/include/std_srvs/TriggerResponse.h
+++ b/roslibrust_genmsg/test_package/include/std_srvs/TriggerResponse.h
@@ -110,7 +110,7 @@ struct HasHeader< ::std_srvs::TriggerResponse_<ContainerAllocator> const>
 template<class ContainerAllocator>
 struct MD5Sum< ::std_srvs::TriggerResponse_<ContainerAllocator>>
 {
-  static const char* value()
+  static constexpr char const * value()
   {
     return "937c9679a518e3a18d831e57125ea522";
   }
@@ -123,7 +123,7 @@ struct MD5Sum< ::std_srvs::TriggerResponse_<ContainerAllocator>>
 template<class ContainerAllocator>
 struct DataType< ::std_srvs::TriggerResponse_<ContainerAllocator>>
 {
-  static const char* value()
+  static constexpr char const* value()
   {
     return "std_srvs/TriggerResponse";
   }
@@ -134,7 +134,7 @@ struct DataType< ::std_srvs::TriggerResponse_<ContainerAllocator>>
 template<class ContainerAllocator>
 struct Definition< ::std_srvs::TriggerResponse_<ContainerAllocator>>
 {
-  static const char* value()
+  static constexpr char const* value()
   {
     return "";
   }

--- a/roslibrust_genmsg/test_package/include/test_package/Test.h
+++ b/roslibrust_genmsg/test_package/include/test_package/Test.h
@@ -32,7 +32,7 @@ struct Test_
     (void)_alloc;
   }
     
-        typedef std::vector<::geometry_msgs::Point32_<ContainerAllocator>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<::geometry_msgs::Point32_<ContainerAllocator>>> _points_type;
+        typedef ::geometry_msgs::Point32_<ContainerAllocator> _points_type;
     _points_type points;
     
         typedef std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>> _test_a_type;
@@ -196,15 +196,10 @@ struct Printer< ::test_package::Test_<ContainerAllocator>>
 {
   template<typename Stream> static void stream(Stream& s, const std::string& indent, const ::test_package::Test_<ContainerAllocator>& v)
   {
-    
-    s << indent << "points[]" << std::endl;
-    for (size_t i = 0; i < v.points.size(); ++i)
-    {
-      s << indent << "  points[" << i << "]: ";
-      s << std::endl;
-      s << indent;
-      Printer<::geometry_msgs::Point32>::stream(s, indent + "    ", v.points[i]);
-    }
+
+    s << indent << "points: ";
+    s << std::endl;
+    Printer< ::geometry_msgs::Point32_<ContainerAllocator>>::stream(s, indent + "  ", v.points);
 
     s << indent << "test_a: ";
     Printer< std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>>>::stream(s, indent + "  ", v.test_a);

--- a/roslibrust_genmsg/test_package/include/test_package/Test.h
+++ b/roslibrust_genmsg/test_package/include/test_package/Test.h
@@ -32,7 +32,7 @@ struct Test_
     (void)_alloc;
   }
     
-        typedef ::geometry_msgs::Point32_<ContainerAllocator> _points_type;
+        typedef std::vector<::geometry_msgs::Point32_<ContainerAllocator>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<::geometry_msgs::Point32_<ContainerAllocator>>> _points_type;
     _points_type points;
     
         typedef std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>> _test_a_type;
@@ -196,10 +196,15 @@ struct Printer< ::test_package::Test_<ContainerAllocator>>
 {
   template<typename Stream> static void stream(Stream& s, const std::string& indent, const ::test_package::Test_<ContainerAllocator>& v)
   {
-
-    s << indent << "points: ";
-    s << std::endl;
-    Printer< ::geometry_msgs::Point32_<ContainerAllocator>>::stream(s, indent + "  ", v.points);
+    
+    s << indent << "points[]" << std::endl;
+    for (size_t i = 0; i < v.points.size(); ++i)
+    {
+      s << indent << "  points[" << i << "]: ";
+      s << std::endl;
+      s << indent;
+      Printer<::geometry_msgs::Point32>::stream(s, indent + "    ", v.points[i]);
+    }
 
     s << indent << "test_a: ";
     Printer< std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>>>::stream(s, indent + "  ", v.test_a);

--- a/roslibrust_genmsg/test_package/include/test_package/Test.h
+++ b/roslibrust_genmsg/test_package/include/test_package/Test.h
@@ -130,7 +130,7 @@ struct HasHeader< ::test_package::Test_<ContainerAllocator> const>
 template<class ContainerAllocator>
 struct MD5Sum< ::test_package::Test_<ContainerAllocator>>
 {
-  static const char* value()
+  static constexpr char const * value()
   {
     return "55941ae53e1a50a2d50c1c9ceab9efc0";
   }
@@ -143,7 +143,7 @@ struct MD5Sum< ::test_package::Test_<ContainerAllocator>>
 template<class ContainerAllocator>
 struct DataType< ::test_package::Test_<ContainerAllocator>>
 {
-  static const char* value()
+  static constexpr char const* value()
   {
     return "test_package/Test";
   }
@@ -154,7 +154,7 @@ struct DataType< ::test_package::Test_<ContainerAllocator>>
 template<class ContainerAllocator>
 struct Definition< ::test_package::Test_<ContainerAllocator>>
 {
-  static const char* value()
+  static constexpr char const* value()
   {
     return "";
   }

--- a/roslibrust_genmsg/test_package/src/test_main.cpp
+++ b/roslibrust_genmsg/test_package/src/test_main.cpp
@@ -18,5 +18,7 @@ int main() {
     std::cout << "Polygon: " << polygon << std::endl;
     std::cout << "Test State: " << test_package::Test::RUNNING_STATE << std::endl;
 
+    static_assert("c9a58c1b0b154e0e6da7578cb991d214" == ros::message_traits::MD5Sum<sensor_msgs::CameraInfo>().value());
+
     return 0;
 }

--- a/roslibrust_genmsg/test_package/src/test_main.cpp
+++ b/roslibrust_genmsg/test_package/src/test_main.cpp
@@ -1,5 +1,6 @@
 #include <ros/ros.h>
 #include "sensor_msgs/BatteryState.h"
+#include "sensor_msgs/CameraInfo.h"
 #include "std_srvs/Trigger.h"
 #include "geometry_msgs/Polygon.h"
 #include "test_package/Test.h"

--- a/roslibrust_genmsg/test_package/src/test_main.cpp
+++ b/roslibrust_genmsg/test_package/src/test_main.cpp
@@ -19,7 +19,7 @@ int main() {
     std::cout << "Polygon: " << polygon << std::endl;
     std::cout << "Test State: " << test_package::Test::RUNNING_STATE << std::endl;
 
-    static_assert("c9a58c1b0b154e0e6da7578cb991d214" == ros::message_traits::MD5Sum<sensor_msgs::CameraInfo>().value());
+    static_assert("c9a58c1b0b154e0e6da7578cb991d214" == ros::message_traits::MD5Sum<sensor_msgs::CameraInfo>::value());
 
     return 0;
 }

--- a/roslibrust_test/src/ros1.rs
+++ b/roslibrust_test/src/ros1.rs
@@ -297,7 +297,7 @@ pub mod geometry_msgs {
     }
     impl ::roslibrust_codegen::RosMessageType for AccelWithCovariance {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/AccelWithCovariance";
-        const MD5SUM: &'static str = "c6f49a48c87b365e434f7864bd9539b3";
+        const MD5SUM: &'static str = "ad5a718d699c6be72a02b8d6a139f334";
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -314,7 +314,7 @@ pub mod geometry_msgs {
     }
     impl ::roslibrust_codegen::RosMessageType for AccelWithCovarianceStamped {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/AccelWithCovarianceStamped";
-        const MD5SUM: &'static str = "016e52c38c5859e083b368a3d2b9493d";
+        const MD5SUM: &'static str = "96adb295225031ec8d57fb4251b0a886";
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -526,7 +526,7 @@ pub mod geometry_msgs {
     }
     impl ::roslibrust_codegen::RosMessageType for PoseWithCovariance {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/PoseWithCovariance";
-        const MD5SUM: &'static str = "5b711e242c1ee70503c6bddce2439ca8";
+        const MD5SUM: &'static str = "c23e848cf1b7533a8d7c259073a97e6f";
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -543,7 +543,7 @@ pub mod geometry_msgs {
     }
     impl ::roslibrust_codegen::RosMessageType for PoseWithCovarianceStamped {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/PoseWithCovarianceStamped";
-        const MD5SUM: &'static str = "e5086028279c8f3d90ed06cdf80d003b";
+        const MD5SUM: &'static str = "953b798c0f514ff060a53a3498ce6246";
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -665,7 +665,7 @@ pub mod geometry_msgs {
     }
     impl ::roslibrust_codegen::RosMessageType for TwistWithCovariance {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/TwistWithCovariance";
-        const MD5SUM: &'static str = "75fcb7b0fec4e5cc35535e727ba979bd";
+        const MD5SUM: &'static str = "1fe8a28e6890a4cc3ae4c3ca5c7d82e6";
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -682,7 +682,7 @@ pub mod geometry_msgs {
     }
     impl ::roslibrust_codegen::RosMessageType for TwistWithCovarianceStamped {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/TwistWithCovarianceStamped";
-        const MD5SUM: &'static str = "10a3ea629eb15f1a2e0dee7b78cdf005";
+        const MD5SUM: &'static str = "8927a1a12fb2607ceea095b2dc440a96";
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -959,7 +959,7 @@ pub mod nav_msgs {
     }
     impl ::roslibrust_codegen::RosMessageType for Odometry {
         const ROS_TYPE_NAME: &'static str = "nav_msgs/Odometry";
-        const MD5SUM: &'static str = "86b740de5f66321fbd1151710f00a7a1";
+        const MD5SUM: &'static str = "cd5e73d190d741a2f92e81eda573aca7";
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -1118,7 +1118,7 @@ pub mod nav_msgs {
     }
     impl ::roslibrust_codegen::RosMessageType for SetMapRequest {
         const ROS_TYPE_NAME: &'static str = "nav_msgs/SetMapRequest";
-        const MD5SUM: &'static str = "d9d2f9021325d8f0a8c0c53c21b6129d";
+        const MD5SUM: &'static str = "91149a20d7be299b87c340df8cc94fd4";
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -1139,7 +1139,7 @@ pub mod nav_msgs {
     pub struct SetMap {}
     impl ::roslibrust_codegen::RosServiceType for SetMap {
         const ROS_SERVICE_NAME: &'static str = "nav_msgs/SetMap";
-        const MD5SUM: &'static str = "406bbe136010dec8b3dd00a499662442";
+        const MD5SUM: &'static str = "c36922319011e63ed7784112ad4fdd32";
         type Request = SetMapRequest;
         type Response = SetMapResponse;
     }
@@ -2330,7 +2330,7 @@ pub mod sensor_msgs {
     }
     impl ::roslibrust_codegen::RosMessageType for CameraInfo {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/CameraInfo";
-        const MD5SUM: &'static str = "0b90a09f7d964437a2b7ac1f61cd712f";
+        const MD5SUM: &'static str = "c9a58c1b0b154e0e6da7578cb991d214";
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -2445,7 +2445,7 @@ pub mod sensor_msgs {
     }
     impl ::roslibrust_codegen::RosMessageType for Imu {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/Imu";
-        const MD5SUM: &'static str = "804641083dde2c712c59e7550a59ce14";
+        const MD5SUM: &'static str = "6a62c6daae103f4ff57a132d6f95cec2";
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -2581,7 +2581,7 @@ pub mod sensor_msgs {
     }
     impl ::roslibrust_codegen::RosMessageType for MagneticField {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/MagneticField";
-        const MD5SUM: &'static str = "160c2cdeafa4a7d6e47ae90519259a0f";
+        const MD5SUM: &'static str = "2f3b0b43eed0c9501de0fa3ff89a45aa";
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -2648,7 +2648,7 @@ pub mod sensor_msgs {
     }
     impl ::roslibrust_codegen::RosMessageType for NavSatFix {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/NavSatFix";
-        const MD5SUM: &'static str = "77d3e0c6052dc39d32312561f077b236";
+        const MD5SUM: &'static str = "2d3a8cd499b9b4a0249fb98fd05cfa48";
     }
     impl NavSatFix {
         pub const r#COVARIANCE_TYPE_UNKNOWN: u8 = 0u8;
@@ -2867,7 +2867,7 @@ pub mod sensor_msgs {
     }
     impl ::roslibrust_codegen::RosMessageType for SetCameraInfoRequest {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/SetCameraInfoRequest";
-        const MD5SUM: &'static str = "05e7b6a643703b76de9d3e6f9cdf8a68";
+        const MD5SUM: &'static str = "ee34be01fdeee563d0d99cd594d5581d";
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -2889,7 +2889,7 @@ pub mod sensor_msgs {
     pub struct SetCameraInfo {}
     impl ::roslibrust_codegen::RosServiceType for SetCameraInfo {
         const ROS_SERVICE_NAME: &'static str = "sensor_msgs/SetCameraInfo";
-        const MD5SUM: &'static str = "c0715e7e0796f9e4fec7c3bd58d253d4";
+        const MD5SUM: &'static str = "bef1df590ed75ed1f393692395e15482";
         type Request = SetCameraInfoRequest;
         type Response = SetCameraInfoResponse;
     }
@@ -2924,7 +2924,7 @@ pub mod shape_msgs {
     }
     impl ::roslibrust_codegen::RosMessageType for Mesh {
         const ROS_TYPE_NAME: &'static str = "shape_msgs/Mesh";
-        const MD5SUM: &'static str = "074b644fc5c01938c4e68ae14f4f0527";
+        const MD5SUM: &'static str = "1ffdae9486cd3316a121c578b47a85cc";
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -2940,7 +2940,7 @@ pub mod shape_msgs {
     }
     impl ::roslibrust_codegen::RosMessageType for MeshTriangle {
         const ROS_TYPE_NAME: &'static str = "shape_msgs/MeshTriangle";
-        const MD5SUM: &'static str = "153f61dee254ce3792e80cfd99cbcee3";
+        const MD5SUM: &'static str = "23688b2e6d2de3d32fe8af104a903253";
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -2956,7 +2956,7 @@ pub mod shape_msgs {
     }
     impl ::roslibrust_codegen::RosMessageType for Plane {
         const ROS_TYPE_NAME: &'static str = "shape_msgs/Plane";
-        const MD5SUM: &'static str = "ab3614b72ca3f82aad54a53021284fb5";
+        const MD5SUM: &'static str = "2c1b92ed8f31492f8e73f6a4a44ca796";
     }
     #[allow(non_snake_case)]
     #[derive(

--- a/roslibrust_test/src/ros2.rs
+++ b/roslibrust_test/src/ros2.rs
@@ -291,7 +291,7 @@ pub mod geometry_msgs {
     }
     impl ::roslibrust_codegen::RosMessageType for AccelWithCovariance {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/AccelWithCovariance";
-        const MD5SUM: &'static str = "c6f49a48c87b365e434f7864bd9539b3";
+        const MD5SUM: &'static str = "ad5a718d699c6be72a02b8d6a139f334";
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -308,7 +308,7 @@ pub mod geometry_msgs {
     }
     impl ::roslibrust_codegen::RosMessageType for AccelWithCovarianceStamped {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/AccelWithCovarianceStamped";
-        const MD5SUM: &'static str = "2ffaa449593251db0b3c12257ba4b247";
+        const MD5SUM: &'static str = "36b6f1177d3c3f476d4c306279c6f18a";
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -520,7 +520,7 @@ pub mod geometry_msgs {
     }
     impl ::roslibrust_codegen::RosMessageType for PoseWithCovariance {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/PoseWithCovariance";
-        const MD5SUM: &'static str = "5b711e242c1ee70503c6bddce2439ca8";
+        const MD5SUM: &'static str = "c23e848cf1b7533a8d7c259073a97e6f";
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -537,7 +537,7 @@ pub mod geometry_msgs {
     }
     impl ::roslibrust_codegen::RosMessageType for PoseWithCovarianceStamped {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/PoseWithCovarianceStamped";
-        const MD5SUM: &'static str = "8d1f95db1811f91535f690acc723630a";
+        const MD5SUM: &'static str = "2178452bf195c1abe1e99b07b4e6c8f0";
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -663,7 +663,7 @@ pub mod geometry_msgs {
     }
     impl ::roslibrust_codegen::RosMessageType for TwistWithCovariance {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/TwistWithCovariance";
-        const MD5SUM: &'static str = "75fcb7b0fec4e5cc35535e727ba979bd";
+        const MD5SUM: &'static str = "1fe8a28e6890a4cc3ae4c3ca5c7d82e6";
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -680,7 +680,7 @@ pub mod geometry_msgs {
     }
     impl ::roslibrust_codegen::RosMessageType for TwistWithCovarianceStamped {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/TwistWithCovarianceStamped";
-        const MD5SUM: &'static str = "5423aed9160897bf26a34981339cc85d";
+        const MD5SUM: &'static str = "7019807c85ce8602fb83180366470670";
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -839,7 +839,7 @@ pub mod nav_msgs {
     }
     impl ::roslibrust_codegen::RosMessageType for Odometry {
         const ROS_TYPE_NAME: &'static str = "nav_msgs/Odometry";
-        const MD5SUM: &'static str = "5554098bea214231bfb444a6df7a41cd";
+        const MD5SUM: &'static str = "81a0900daae2c6c0acc71c9f8df88947";
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -998,7 +998,7 @@ pub mod nav_msgs {
     }
     impl ::roslibrust_codegen::RosMessageType for SetMapRequest {
         const ROS_TYPE_NAME: &'static str = "nav_msgs/SetMapRequest";
-        const MD5SUM: &'static str = "1362070bf1594e3c3a800b8a926ae808";
+        const MD5SUM: &'static str = "98782a373ad73e1165352caf85923850";
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -1019,7 +1019,7 @@ pub mod nav_msgs {
     pub struct SetMap {}
     impl ::roslibrust_codegen::RosServiceType for SetMap {
         const ROS_SERVICE_NAME: &'static str = "nav_msgs/SetMap";
-        const MD5SUM: &'static str = "3259327d9856c8a615675f6c7f0d4420";
+        const MD5SUM: &'static str = "6c3f8182fbcb3d4ee7aef02d1dcd1e16";
         type Request = SetMapRequest;
         type Response = SetMapResponse;
     }
@@ -1115,7 +1115,7 @@ pub mod sensor_msgs {
     }
     impl ::roslibrust_codegen::RosMessageType for CameraInfo {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/CameraInfo";
-        const MD5SUM: &'static str = "6ed1374c273af05e0a4310d74bacbaff";
+        const MD5SUM: &'static str = "47b55ddbbf2ec398f94cddf328bbc2ac";
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -1230,7 +1230,7 @@ pub mod sensor_msgs {
     }
     impl ::roslibrust_codegen::RosMessageType for Imu {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/Imu";
-        const MD5SUM: &'static str = "0778670fb00acae60a84a9e24c1d1400";
+        const MD5SUM: &'static str = "058a92f712764b4ade1563e82041c569";
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -1366,7 +1366,7 @@ pub mod sensor_msgs {
     }
     impl ::roslibrust_codegen::RosMessageType for MagneticField {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/MagneticField";
-        const MD5SUM: &'static str = "baa70b1dbaa90fd66e5241377ca453f6";
+        const MD5SUM: &'static str = "c8761d20eb9dc59addd882f1d4de2266";
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -1433,7 +1433,7 @@ pub mod sensor_msgs {
     }
     impl ::roslibrust_codegen::RosMessageType for NavSatFix {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/NavSatFix";
-        const MD5SUM: &'static str = "4772ea7752199e85449ef71667f9101e";
+        const MD5SUM: &'static str = "faa1756146a6a934d7e4ef0e3855c531";
     }
     impl NavSatFix {
         pub const r#COVARIANCE_TYPE_UNKNOWN: u8 = 0u8;
@@ -1652,7 +1652,7 @@ pub mod sensor_msgs {
     }
     impl ::roslibrust_codegen::RosMessageType for SetCameraInfoRequest {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/SetCameraInfoRequest";
-        const MD5SUM: &'static str = "d01d173ac0f730f0076e8b9ecabcf422";
+        const MD5SUM: &'static str = "251c96e357751cc7c699c496178141d5";
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -1674,7 +1674,7 @@ pub mod sensor_msgs {
     pub struct SetCameraInfo {}
     impl ::roslibrust_codegen::RosServiceType for SetCameraInfo {
         const ROS_SERVICE_NAME: &'static str = "sensor_msgs/SetCameraInfo";
-        const MD5SUM: &'static str = "05fe977980e126fa16e30568dad4042f";
+        const MD5SUM: &'static str = "c191a50a3d5730b8679f4b95b3948b15";
         type Request = SetCameraInfoRequest;
         type Response = SetCameraInfoResponse;
     }
@@ -1707,7 +1707,7 @@ pub mod shape_msgs {
     }
     impl ::roslibrust_codegen::RosMessageType for Mesh {
         const ROS_TYPE_NAME: &'static str = "shape_msgs/Mesh";
-        const MD5SUM: &'static str = "074b644fc5c01938c4e68ae14f4f0527";
+        const MD5SUM: &'static str = "1ffdae9486cd3316a121c578b47a85cc";
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -1723,7 +1723,7 @@ pub mod shape_msgs {
     }
     impl ::roslibrust_codegen::RosMessageType for MeshTriangle {
         const ROS_TYPE_NAME: &'static str = "shape_msgs/MeshTriangle";
-        const MD5SUM: &'static str = "153f61dee254ce3792e80cfd99cbcee3";
+        const MD5SUM: &'static str = "23688b2e6d2de3d32fe8af104a903253";
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -1739,7 +1739,7 @@ pub mod shape_msgs {
     }
     impl ::roslibrust_codegen::RosMessageType for Plane {
         const ROS_TYPE_NAME: &'static str = "shape_msgs/Plane";
-        const MD5SUM: &'static str = "ab3614b72ca3f82aad54a53021284fb5";
+        const MD5SUM: &'static str = "2c1b92ed8f31492f8e73f6a4a44ca796";
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -1757,7 +1757,7 @@ pub mod shape_msgs {
     }
     impl ::roslibrust_codegen::RosMessageType for SolidPrimitive {
         const ROS_TYPE_NAME: &'static str = "shape_msgs/SolidPrimitive";
-        const MD5SUM: &'static str = "64566630a0f2fc6b0e02f71ceb36fd48";
+        const MD5SUM: &'static str = "0cdf91a0a45ccd7bc1e0deb784cb2958";
     }
     impl SolidPrimitive {
         pub const r#BOX: u8 = 1u8;


### PR DESCRIPTION
This MR introduces support for parsing fixed-size arrays and carrying their metadata around to the code generators. There's still a little support required in order to support fixed-size arrays in Rust code due to a lack of support in `serde`, however there is a possible workaround that I will investigate in a follow-up MR: https://github.com/serde-rs/serde/issues/631#issuecomment-322677033

The impetus for this was incorrect code generation for `sensor_msgs/CameraInfo` which has a relatively complex definition. As a result, I've added it to the `test_package` for C++. In order to detect regressions in checksum (and therefore parsing), I augmented some of the `ros::message_traits` structs/functions to use `constexpr` which allows checking the value in a `static_assert`. This should be backwards-compatible and purely an upgrade from a client code perspective.