### PR TITLE
Improve test logging, fix a variety of compiler warnings

### DIFF
--- a/.github/workflows/noetic.yml
+++ b/.github/workflows/noetic.yml
@@ -34,4 +34,4 @@ jobs:
       - name: Start rosbridge
         run: source /opt/ros/noetic/setup.bash; roslaunch rosbridge_server rosbridge_websocket.launch & disown; rosrun rosapi rosapi_node & sleep 1
       - name: Integration Tests
-        run: source /root/.cargo/env; cargo test --features ros1_test,ros1 -- --test-threads 1
+        run: source /root/.cargo/env; cargo test --features ros1_test,ros1,running_bridge,rosapi -- --test-threads 1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1132,6 +1132,7 @@ dependencies = [
  "async-trait",
  "dashmap",
  "deadqueue",
+ "env_logger",
  "futures",
  "futures-util",
  "gethostname",
@@ -1148,6 +1149,7 @@ dependencies = [
  "serde_xmlrpc",
  "simple_logger",
  "smart-default",
+ "test-log",
  "thiserror",
  "tokio",
  "tokio-tungstenite",
@@ -1461,6 +1463,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "test-log"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9601d162c1d77e62c1ea0bc8116cd1caf143ce3af947536c3c9052a1677fe0c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/roslibrust/Cargo.toml
+++ b/roslibrust/Cargo.toml
@@ -37,6 +37,8 @@ hyper = { version = "0.14", features = ["server"], optional = true } # Only used
 gethostname = { version = "0.4", optional = true } # Only used with native ros1
 
 [dev-dependencies]
+env_logger = "0.10"
+test-log = "0.2"
 simple_logger = "2.1.0"
 
 [features]

--- a/roslibrust/examples/native_ros1.rs
+++ b/roslibrust/examples/native_ros1.rs
@@ -13,7 +13,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         .init()
         .unwrap();
 
-    let nh = NodeHandle::new("http://localhost:11311", "native_ros1").await?;
+    let _nh = NodeHandle::new("http://localhost:11311", "native_ros1").await?;
 
     // Work to do:
     // * [DONE] Take the ros MasterApi and create valid in/out types for each api call

--- a/roslibrust/src/ros1/master_client.rs
+++ b/roslibrust/src/ros1/master_client.rs
@@ -1,14 +1,6 @@
 //! This module is concerned with direct communication over xmlprc between the master
 
-use std::{
-    convert::Infallible,
-    net::{Ipv4Addr, SocketAddr},
-};
-
-use hyper::{Body, Response, StatusCode};
 use log::*;
-
-use crate::NodeHandle;
 
 #[derive(thiserror::Error, Debug)]
 pub enum RosMasterError {
@@ -304,13 +296,13 @@ mod test {
     }
 
     // Testing MasterClient's get_uri function returns a non-empty string
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_get_uri() -> Result<(), RosMasterError> {
         assert!(!test_client().await?.get_uri().await?.is_empty());
         Ok(())
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_get_topic_types() {
         let topic_types = test_client()
             .await
@@ -321,7 +313,7 @@ mod test {
         assert!(!topic_types.is_empty());
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_register_and_unregister_service() {
         let client = test_client().await.unwrap();
         let service = "/my_service";
@@ -342,7 +334,7 @@ mod test {
             .unwrap());
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_register_and_unregister_subscriber() {
         let client = test_client().await.unwrap();
 
@@ -355,7 +347,7 @@ mod test {
         client.unregister_subscriber(topic).await.unwrap();
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_register_and_unregister_publisher() {
         let client = test_client().await.unwrap();
 
@@ -368,7 +360,7 @@ mod test {
         assert!(client.unregister_publisher(topic).await.unwrap());
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_lookup_node() {
         let client = test_client().await.unwrap();
         let node_name = "/rosout";
@@ -376,7 +368,7 @@ mod test {
         assert!(!node_uri.is_empty());
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_get_published_topics() {
         let client = test_client().await.unwrap();
         let subgraph = "";

--- a/roslibrust/src/ros1/node_server.rs
+++ b/roslibrust/src/ros1/node_server.rs
@@ -119,7 +119,7 @@ impl NodeServer {
             }
             "publisherUpdate" => {
                 debug!("publisherUpdate called by {args:?}");
-                let (caller_id, topic, publishers): (String, String, Vec<String>) =
+                let (_caller_id, topic, publishers): (String, String, Vec<String>) =
                     serde_xmlrpc::from_values(args).map_err(|e| {
                         Self::error_mapper(
                             e,
@@ -235,7 +235,7 @@ mod test {
         value
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_get_master_uri() {
         let nh = NodeHandle::new("http://localhost:11311", "/get_master_uri_test_node")
             .await
@@ -251,7 +251,7 @@ mod test {
         assert_eq!(uri, "http://localhost:11311");
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_get_subscriptions() {
         // Stub test until we can actually subscribe
         let nh = NodeHandle::new("http://localhost:11311", "/get_subscriptions_test_node")
@@ -270,7 +270,7 @@ mod test {
         // TODO assert we get our subscription back here
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_get_publications() {
         // Stub test until we can actually advertise
         let nh = NodeHandle::new("http://localhost:11311", "/get_subscriptions_test_node")

--- a/roslibrust/src/rosapi/mod.rs
+++ b/roslibrust/src/rosapi/mod.rs
@@ -390,13 +390,13 @@ mod test {
         ClientHandle::new_with_options(opts).await.unwrap()
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn rosapi_get_time() {
         let api = fixture_client().await;
         api.get_time().await.unwrap();
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn rosapi_get_topic_type() {
         let api = fixture_client().await;
         let res = api
@@ -406,7 +406,7 @@ mod test {
         assert_eq!(res.r#type, "rosgraph_msgs/Log");
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn rosapi_get_topics_for_type() {
         let api = fixture_client().await;
         let res = api
@@ -416,14 +416,14 @@ mod test {
         assert!(res.topics.iter().any(|f| f == "/rosout"));
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn rosapi_get_nodes() {
         let api = fixture_client().await;
         let nodes = api.get_nodes().await.expect("Failed to get nodes");
         assert!(nodes.nodes.iter().any(|f| f == "/rosapi"));
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn rosapi_get_node_details() {
         let api = fixture_client().await;
         assert!(
@@ -436,7 +436,7 @@ mod test {
         );
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn rosapi_get_node_for_service() {
         let api = fixture_client().await;
         assert_eq!(
@@ -448,7 +448,7 @@ mod test {
         );
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn rosapi_param_roundtrip() {
         let api = fixture_client().await;
         const PARAM_NAME: &'static str = "/rosapi_param_roundtrip";
@@ -481,7 +481,7 @@ mod test {
         assert!(!api.has_param(PARAM_NAME).await.unwrap().exists);
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn rosapi_message_details() {
         let api = fixture_client().await;
         let response = api.message_details("std_msgs/Header").await.unwrap();
@@ -492,21 +492,21 @@ mod test {
             .any(|t| t.fieldtypes.contains(&"time".to_string())));
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn rosapi_publishers() {
         let api = fixture_client().await;
         let response = api.publishers("/rosout").await.unwrap();
         assert!(response.publishers.iter().any(|p| p == "/rosapi"));
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn rosapi_service_providers() {
         let api = fixture_client().await;
         let response = api.service_providers("rosapi/ServiceHost").await.unwrap();
         assert!(response.providers.iter().any(|p| p == "/rosapi"));
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn rosapi_service_request_details() {
         let api = fixture_client().await;
         let response = api
@@ -517,7 +517,7 @@ mod test {
         assert!(response.typedefs[0].fieldnames.len() == 2);
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn rosapi_service_response_details() {
         let api = fixture_client().await;
         let response = api
@@ -528,14 +528,14 @@ mod test {
         assert_eq!(response.typedefs[0].fieldnames[0], "value");
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn rosapi_get_service_type() {
         let api = fixture_client().await;
         let response = api.get_service_type("/rosapi/node_details").await.unwrap();
         assert_eq!(response.r#type, "rosapi/NodeDetails");
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn rosapi_services() {
         let api = fixture_client().await;
         let response = api.get_services().await.unwrap();

--- a/roslibrust/src/rosbridge/integration_tests.rs
+++ b/roslibrust/src/rosbridge/integration_tests.rs
@@ -48,17 +48,11 @@ mod integration_tests {
     Requires a running local rosbridge
     TODO figure out how to automate setting up the needed environment for this
     */
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn self_publish() {
-        // TODO figure out better logging for tests
-        let _ = simple_logger::SimpleLogger::new()
-            .with_level(log::LevelFilter::Debug)
-            .without_timestamps()
-            .init();
-
         const TOPIC: &str = "self_publish";
         // 100ms allowance for connecting so tests still fails
-        let mut client = timeout(TIMEOUT, ClientHandle::new(LOCAL_WS))
+        let client = timeout(TIMEOUT, ClientHandle::new(LOCAL_WS))
             .await
             .expect("Failed to create client in time")
             .unwrap();
@@ -101,12 +95,12 @@ mod integration_tests {
         assert_eq!(msg_in, msg_out);
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     /// Designed to test behavior when receiving a message of unexpected type on a topic
     // TODO this test is good, but actually shows how bad the ergonomics are and how we want to improve them!
     // We want a failed message parse / type mismatch to come through to the subscriber
     async fn bad_message_recv() -> TestResult {
-        let mut client =
+        let client =
             ClientHandle::new_with_options(ClientHandleOptions::new(LOCAL_WS).timeout(TIMEOUT))
                 .await?;
 
@@ -136,7 +130,7 @@ mod integration_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn timeouts_new() {
         // Intentionally a port where there won't be a server at
         let opts = ClientHandleOptions::new("ws://localhost:9091").timeout(TIMEOUT);
@@ -151,9 +145,9 @@ mod integration_tests {
 
     /// This test doesn't actually do much, but instead confirms the internal structure of the lib is multi-threaded correctly
     /// The whole goal here is to catch send / sync complier errors
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn parallel_construction() {
-        let mut client = timeout(TIMEOUT, ClientHandle::new(LOCAL_WS))
+        let client = timeout(TIMEOUT, ClientHandle::new(LOCAL_WS))
             .await
             .expect("Timeout constructing client")
             .expect("Failed to construct client");
@@ -175,7 +169,7 @@ mod integration_tests {
     }
 
     /// Tests that dropping a publisher correctly unadvertises
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     // This test is currently broken, it seems that rosbridge still sends the message regardless
     // of advertise / unadvertise status. Unclear how to confirm whether unadvertise was sent or not
     #[ignore]
@@ -195,7 +189,7 @@ mod integration_tests {
 
         let opt = ClientHandleOptions::new(LOCAL_WS).timeout(TIMEOUT);
 
-        let mut client = ClientHandle::new_with_options(opt).await?;
+        let client = ClientHandle::new_with_options(opt).await?;
         let publisher = client.advertise(TOPIC).await?;
         debug!("Got publisher");
 
@@ -235,15 +229,10 @@ mod integration_tests {
     // It may be that ros2 prevents a "service_loop" where a node calls a service on itself?
     // unclear...
     #[cfg(feature = "ros1_test")]
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn self_service_call() -> TestResult {
-        let _ = simple_logger::SimpleLogger::new()
-            .with_level(log::LevelFilter::Debug)
-            .without_timestamps()
-            .init();
-
         let opt = ClientHandleOptions::new(LOCAL_WS).timeout(TIMEOUT);
-        let mut client = ClientHandle::new_with_options(opt).await?;
+        let client = ClientHandle::new_with_options(opt).await?;
 
         let cb =
             |_req: SetBoolRequest| -> Result<SetBoolResponse, Box<dyn std::error::Error + Send + Sync>> {
@@ -284,7 +273,7 @@ mod integration_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_strong_and_weak_client_counts() -> TestResult {
         let opt = ClientHandleOptions::new(LOCAL_WS).timeout(TIMEOUT);
         let client = ClientHandle::new_with_options(opt).await?;
@@ -314,7 +303,7 @@ mod integration_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_disconnect_returns_error() -> TestResult {
         let client =
             ClientHandle::new_with_options(ClientHandleOptions::new(LOCAL_WS).timeout(TIMEOUT))
@@ -329,9 +318,9 @@ mod integration_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn working_with_char() -> TestResult {
-        let mut client =
+        let client =
             ClientHandle::new_with_options(ClientHandleOptions::new(LOCAL_WS).timeout(TIMEOUT))
                 .await?;
 
@@ -357,7 +346,7 @@ mod integration_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn error_on_non_existent_service() -> TestResult {
         // This test is designed to catch a specific error raised in issue #88
         // When roslibrust expereiences a server side error, it returns a string instead of our message

--- a/roslibrust/src/rosbridge/topic_provider.rs
+++ b/roslibrust/src/rosbridge/topic_provider.rs
@@ -97,19 +97,19 @@ mod test {
     // }
 
     // This tests proves that you could use topic provider in a compile time api, but not object safe...
-    #[test]
+    #[test_log::test]
     #[should_panic]
     fn topic_proivder_can_be_used_at_compile_time() {
         struct MyClient<T: TopicProvider> {
-            client: T,
+            _client: T,
         }
 
         // Kinda a hack way to make the compiler prove it could construct a MyClient<ClientHandle> with out actually
         // constructing one at runtime
         let new_mock: Result<ClientHandle, _> = Err(anyhow::anyhow!("Expected error"));
 
-        let x = MyClient {
-            client: new_mock.unwrap(),
+        let _x = MyClient {
+            _client: new_mock.unwrap(),
         };
     }
 }


### PR DESCRIPTION
Rolls out test_log usage to core roslibrust crate.
Fixes that we weren't testing with all features in CI (Major TODO to test matrix of features)
Fixes many warnings (but not all, because quite a few are legit)