### PR TITLE
ROS1 Native publishing first pass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,30 @@
 version = 3
 
 [[package]]
+name = "abort-on-drop"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dd6d700ad9af641490c1f7d67980d2de4d1433016e5b12f819448d3c832142a"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,6 +117,21 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "base64"
@@ -376,6 +415,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-chain"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8"
+dependencies = [
+ "backtrace",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -533,6 +581,12 @@ dependencies = [
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
 name = "h2"
@@ -828,6 +882,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -894,6 +957,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.30.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03b4680b86d9cfafba8fc491dc9b6df26b68cf40e9e6cd73909194759a63c385"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1128,8 +1200,10 @@ dependencies = [
 name = "roslibrust"
 version = "0.7.0"
 dependencies = [
+ "abort-on-drop",
  "anyhow",
  "async-trait",
+ "byteorder",
  "dashmap",
  "deadqueue",
  "env_logger",
@@ -1146,6 +1220,7 @@ dependencies = [
  "roslibrust_codegen_macro",
  "serde",
  "serde_json",
+ "serde_rosmsg",
  "serde_xmlrpc",
  "simple_logger",
  "smart-default",
@@ -1214,6 +1289,12 @@ dependencies = [
  "serde_json",
  "smart-default",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
@@ -1320,6 +1401,18 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_rosmsg"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e55d20c8bff70e82b5948a187c77d93c34fa538ae3d9999597fbb6245993680"
+dependencies = [
+ "byteorder",
+ "error-chain",
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]

--- a/roslibrust/Cargo.toml
+++ b/roslibrust/Cargo.toml
@@ -63,7 +63,7 @@ running_bridge = []
 ros1_test = ["running_bridge"]
 # For use with integration tests, indicates we are testing integration with a ros2 bridge
 ros2_test = ["running_bridge"]
-# Provides access to experimental abstrac trait topic_provider
+# Provides access to experimental abstract trait topic_provider
 topic_provider = []
 # Provides a ros1 xmlrpc / TCPROS client
 ros1 = [
@@ -74,6 +74,11 @@ ros1 = [
     "dep:serde_rosmsg",
 ]
 
+
+[[test]]
+name = "ros1_xmlrpc"
+path = "tests/ros1_xmlrpc.rs"
+required-features = ["ros1_test", "ros1"]
 
 [package.metadata.docs.rs]
 features = ["all"]

--- a/roslibrust/Cargo.toml
+++ b/roslibrust/Cargo.toml
@@ -11,8 +11,10 @@ keywords = ["ROS", "robotics", "websocket", "json", "async"]
 categories = ["science::robotics"]
 
 [dependencies]
+abort-on-drop = "0.2"
 anyhow = "1.0"
 async-trait = "0.1"
+byteorder = "1.4"
 dashmap = "5.3"
 deadqueue = "0.2.4" # .4+ is required to fix bug with missing tokio dep
 futures = "0.3"
@@ -25,7 +27,12 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 smart-default = "0.6"
 thiserror = "1.0"
-tokio = { version = "1.20", features = ["net", "macros", "time", "rt-multi-thread"] }
+tokio = { version = "1.20", features = [
+    "net",
+    "macros",
+    "time",
+    "rt-multi-thread",
+] }
 tokio-tungstenite = { version = "0.17" }
 uuid = { version = "1.1", features = ["v4"] }
 roslibrust_codegen_macro = { path = "../roslibrust_codegen_macro", version = "0.7.0" }
@@ -33,7 +40,10 @@ roslibrust_codegen = { path = "../roslibrust_codegen", version = "0.7.0" }
 reqwest = { version = "0.11", optional = true } # Only used with native ros1
 # serde_xmlrpc = { version = "0.1.2", optional = true } # Only used with native ros1
 serde_xmlrpc = { git = "https://github.com/belak/serde-xmlrpc.git", branch = "main", optional = true } # Belak should be release v0.2 soon
-hyper = { version = "0.14", features = ["server"], optional = true } # Only used with native ros1
+serde_rosmsg = { version = "0.2", optional = true } # Only used with native ros1
+hyper = { version = "0.14", features = [
+    "server",
+], optional = true } # Only used with native ros1
 gethostname = { version = "0.4", optional = true } # Only used with native ros1
 
 [dev-dependencies]
@@ -56,7 +66,13 @@ ros2_test = ["running_bridge"]
 # Provides access to experimental abstrac trait topic_provider
 topic_provider = []
 # Provides a ros1 xmlrpc / TCPROS client
-ros1 = ["dep:serde_xmlrpc", "dep:reqwest", "dep:hyper", "dep:gethostname"]
+ros1 = [
+    "dep:serde_xmlrpc",
+    "dep:reqwest",
+    "dep:hyper",
+    "dep:gethostname",
+    "dep:serde_rosmsg",
+]
 
 
 [package.metadata.docs.rs]

--- a/roslibrust/examples/native_ros1.rs
+++ b/roslibrust/examples/native_ros1.rs
@@ -4,7 +4,7 @@
 
 #[cfg(feature = "ros1")]
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     use roslibrust::NodeHandle;
 
     simple_logger::SimpleLogger::new()

--- a/roslibrust/examples/ros1_talker.rs
+++ b/roslibrust/examples/ros1_talker.rs
@@ -27,3 +27,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
+
+#[cfg(not(feature = "ros1"))]
+fn main() {
+    eprintln!("This example does nothing without compiling with the feature 'ros1'");
+}

--- a/roslibrust/examples/ros1_talker.rs
+++ b/roslibrust/examples/ros1_talker.rs
@@ -16,15 +16,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .map_err(|err| err)?;
     let publisher = nh.advertise::<std_msgs::String>("/chatter", 1).await?;
 
-    let mut counter = 0u32;
-
-    while counter < 1000 {
+    for count in 0..1000 {
         publisher
             .publish(&std_msgs::String {
-                data: format!("hello world from rust {counter}"),
+                data: format!("hello world from rust {count}"),
             })
             .await?;
-        counter = counter.wrapping_add_signed(1);
         tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
     }
 

--- a/roslibrust/examples/ros1_talker.rs
+++ b/roslibrust/examples/ros1_talker.rs
@@ -1,0 +1,32 @@
+roslibrust_codegen_macro::find_and_generate_ros_messages!("assets/ros1_common_interfaces/std_msgs");
+
+#[cfg(feature = "ros1")]
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use roslibrust::NodeHandle;
+
+    simple_logger::SimpleLogger::new()
+        .with_level(log::LevelFilter::Debug)
+        .without_timestamps() // required for running wsl2
+        .init()
+        .unwrap();
+
+    let nh = NodeHandle::new("http://localhost:11311", "talker_rs")
+        .await
+        .map_err(|err| err)?;
+    let publisher = nh.advertise::<std_msgs::String>("/chatter", 1).await?;
+
+    let mut counter = 0u32;
+
+    while counter < 1000 {
+        publisher
+            .publish(&std_msgs::String {
+                data: format!("hello world from rust {counter}"),
+            })
+            .await?;
+        counter = counter.wrapping_add_signed(1);
+        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+    }
+
+    Ok(())
+}

--- a/roslibrust/src/ros1/master_client.rs
+++ b/roslibrust/src/ros1/master_client.rs
@@ -241,7 +241,7 @@ impl MasterClient {
         self.post(body).await
     }
 
-    /// Hits the master's xmlrpc endpoint "unreisterPublisher", returns true if the subscriber was registered
+    /// Hits the master's xmlrpc endpoint "unregisterPublisher", returns true if the subscriber was registered
     /// for the topic and false if the server reported this operation as a no-op.
     pub async fn unregister_publisher(
         &self,

--- a/roslibrust/src/ros1/mod.rs
+++ b/roslibrust/src/ros1/mod.rs
@@ -5,9 +5,12 @@ mod master_client;
 pub use master_client::*;
 
 /// [node_server] module contains the xmlrpc server that a node must host
-mod node_server;
-pub(crate) use node_server::*;
+mod xmlrpc_server;
+pub(crate) use xmlrpc_server::*;
 
 /// [node] module contains the central Node and NodeHandle APIs
 mod node;
 pub use node::*;
+
+mod publisher;
+mod tcpros;

--- a/roslibrust/src/ros1/mod.rs
+++ b/roslibrust/src/ros1/mod.rs
@@ -4,7 +4,7 @@
 mod master_client;
 pub use master_client::*;
 
-/// [node_server] module contains the xmlrpc server that a node must host
+/// [xmlrpc_server] module contains the xmlrpc server that a node must host
 mod xmlrpc_server;
 pub(crate) use xmlrpc_server::*;
 

--- a/roslibrust/src/ros1/node.rs
+++ b/roslibrust/src/ros1/node.rs
@@ -1,54 +1,353 @@
 //! This module contains the top level Node and NodeHandle classes.
 //! These wrap the lower level management of a ROS Node connection into a higher level and thread safe API.
 
-use std::{
-    net::{IpAddr, Ipv4Addr, ToSocketAddrs},
-    sync::Arc,
-};
-
-use dashmap::DashMap;
-use log::warn;
-
+use super::publisher::{Publisher, PublishingChannel};
 use crate::{
-    MasterClient, NodeServer, PublisherHandle, RosMasterError, ServiceCallback, Subscription,
+    MasterClient, PublisherHandle, RosMasterError, ServiceCallback, Subscription, XmlRpcServer,
+    XmlRpcServerHandle,
 };
+use dashmap::DashMap;
+use roslibrust_codegen::RosMessageType;
+use std::net::{IpAddr, Ipv4Addr, ToSocketAddrs};
+use tokio::sync::{mpsc, oneshot};
+
+#[derive(Debug)]
+pub struct ProtocolParams {
+    pub hostname: String,
+    pub protocol: String,
+    pub port: u16,
+}
+
+#[derive(Debug)]
+pub enum NodeMsg {
+    GetMasterUri {
+        reply: oneshot::Sender<String>,
+    },
+    GetSubscriptions {
+        reply: oneshot::Sender<Vec<(String, String)>>,
+    },
+    GetPublications {
+        reply: oneshot::Sender<Vec<(String, String)>>,
+    },
+    SetPeerPublishers {
+        topic: String,
+        publishers: Vec<String>,
+    },
+    Shutdown,
+    RegisterPublisher {
+        reply: oneshot::Sender<Result<mpsc::Sender<Vec<u8>>, String>>,
+        topic: String,
+        topic_type: String,
+        queue_size: usize,
+        msg_definition: String,
+        md5sum: String,
+    },
+    RequestTopic {
+        reply: oneshot::Sender<Result<ProtocolParams, String>>,
+        caller_id: String,
+        topic: String,
+        protocols: Vec<String>,
+    },
+}
+
+#[derive(Clone)]
+pub(crate) struct NodeServerHandle {
+    node_server_sender: mpsc::UnboundedSender<NodeMsg>,
+}
+
+impl NodeServerHandle {
+    /// Get the URI of the master node.
+    pub async fn get_master_uri(&self) -> Result<String, Box<dyn std::error::Error>> {
+        let (sender, receiver) = oneshot::channel();
+        match self
+            .node_server_sender
+            .send(NodeMsg::GetMasterUri { reply: sender })
+        {
+            Ok(()) => Ok(receiver.await.map_err(|err| Box::new(err))?),
+            Err(e) => Err(Box::new(e)),
+        }
+    }
+
+    /// Gets the list of topics the node is currently subscribed to.
+    /// Returns a tuple of (Topic Name, Topic Type) e.g. ("/rosout", "rosgraph_msgs/Log").
+    pub async fn get_subscriptions(
+        &self,
+    ) -> Result<Vec<(String, String)>, Box<dyn std::error::Error>> {
+        let (sender, receiver) = oneshot::channel();
+        match self
+            .node_server_sender
+            .send(NodeMsg::GetSubscriptions { reply: sender })
+        {
+            Ok(()) => Ok(receiver.await.map_err(|err| Box::new(err))?),
+            Err(e) => Err(Box::new(e)),
+        }
+    }
+
+    /// Gets the list of topic the node is currently publishing to.
+    /// Returns a tuple of (Topic Name, Topic Type) e.g. ("/rosout", "rosgraph_msgs/Log").
+    pub async fn get_publications(
+        &self,
+    ) -> Result<Vec<(String, String)>, Box<dyn std::error::Error>> {
+        let (sender, receiver) = oneshot::channel();
+        match self
+            .node_server_sender
+            .send(NodeMsg::GetPublications { reply: sender })
+        {
+            Ok(()) => Ok(receiver.await.map_err(|err| Box::new(err))?),
+            Err(e) => Err(Box::new(e)),
+        }
+    }
+
+    /// Updates the list of know publishers for a given topic
+    /// This is used to know who to reach out to for updates
+    pub fn set_peer_publishers(
+        &self,
+        topic: String,
+        publishers: Vec<String>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        Ok(self
+            .node_server_sender
+            .send(NodeMsg::SetPeerPublishers { topic, publishers })
+            .map_err(|err| Box::new(err))?)
+    }
+
+    pub async fn register_publisher<T: RosMessageType>(
+        &self,
+        topic: &str,
+        topic_type: &str,
+        queue_size: usize,
+    ) -> Result<mpsc::Sender<Vec<u8>>, Box<dyn std::error::Error>> {
+        let (sender, receiver) = oneshot::channel();
+        match self.node_server_sender.send(NodeMsg::RegisterPublisher {
+            reply: sender,
+            topic: topic.to_owned(),
+            topic_type: topic_type.to_owned(),
+            queue_size,
+            msg_definition: T::DEFINITION.to_owned(),
+            md5sum: T::MD5SUM.to_owned(),
+        }) {
+            Ok(()) => {
+                let received = receiver.await.map_err(|err| Box::new(err))?;
+                Ok(received.map_err(|err| {
+                    log::error!("Failed to register publisher: {err}");
+                    Box::new(std::io::Error::from(std::io::ErrorKind::ConnectionAborted))
+                })?)
+            }
+            Err(err) => Err(Box::new(err)),
+        }
+    }
+
+    pub async fn request_topic(
+        &self,
+        caller_id: &str,
+        topic: &str,
+        protocols: &[String],
+    ) -> Result<ProtocolParams, Box<dyn std::error::Error>> {
+        let (sender, receiver) = oneshot::channel();
+        match self.node_server_sender.send(NodeMsg::RequestTopic {
+            caller_id: caller_id.to_owned(),
+            topic: topic.to_owned(),
+            protocols: protocols.into(),
+            reply: sender,
+        }) {
+            Ok(()) => {
+                let received = receiver.await.map_err(|err| Box::new(err))?;
+                Ok(received.map_err(|err| {
+                    log::error!(
+                        "Fail to coordinate channel between publisher and subscriber: {err}"
+                    );
+                    Box::new(std::io::Error::from(std::io::ErrorKind::AddrNotAvailable))
+                })?)
+            }
+            Err(e) => Err(Box::new(e)),
+        }
+    }
+}
 
 /// Represents a single "real" node, typically only one of these is expected per process
 /// but nothing should specifically prevent that.
 pub struct Node {
     // The xmlrpc client this node uses to make requests to master
-    client: Option<MasterClient>,
-    // Record of what this node publishes
-    publishers: DashMap<String, PublisherHandle>,
+    client: MasterClient,
+    // Server which handles updates from the rosmaster and other ROS nodes
+    _xmlrpc_server: XmlRpcServerHandle,
+    // Receiver for requests to the Node actor
+    node_msg_rx: mpsc::UnboundedReceiver<NodeMsg>,
+    // Map of topic names to the publishing channels associated with the topic
+    publishers: DashMap<String, PublishingChannel>,
     // Record of subscriptions this node has
     subscriptions: DashMap<String, Subscription>,
     // Record of what services this node is serving
     services: DashMap<String, ServiceCallback>,
     // TODO need signal to shutdown xmlrpc server when node is dropped
+    host_addr: Ipv4Addr,
+    hostname: String,
+    node_name: String,
 }
 
 impl Node {
-    // TODO better error
-    async fn new() -> Result<Node, Box<dyn std::error::Error + Send + Sync>> {
-        // We have an initialization loop, because we don't have all the information we
-        // need to create our client until we spawn our server and actually bind our
-        // local TCP port, but our server needs a NodeHandle...
-        // So I'm breaking RAII and assigning client after construction.
-        Ok(Node {
-            client: None,
+    async fn new(
+        master_uri: &str,
+        hostname: &str,
+        node_name: &str,
+        addr: Ipv4Addr,
+    ) -> Result<NodeServerHandle, Box<dyn std::error::Error>> {
+        let (node_sender, node_receiver) = mpsc::unbounded_channel();
+        let node_server_handle = NodeServerHandle {
+            node_server_sender: node_sender,
+        };
+        // Create our xmlrpc server and bind our socket so we know our port and can determine our local URI
+        let xmlrpc_server = XmlRpcServer::new(addr, node_server_handle.clone());
+        let client_uri = format!("http://{hostname}:{}", xmlrpc_server.port());
+
+        let rosmaster_client = MasterClient::new(master_uri, client_uri, node_name).await?;
+        let mut node = Self {
+            client: rosmaster_client,
+            _xmlrpc_server: xmlrpc_server,
+            node_msg_rx: node_receiver,
             publishers: DashMap::new(),
             subscriptions: DashMap::new(),
             services: DashMap::new(),
-        })
+            host_addr: addr,
+            hostname: hostname.to_owned(),
+            node_name: node_name.to_owned(),
+        };
+
+        tokio::spawn(async move {
+            loop {
+                match node.node_msg_rx.recv().await {
+                    Some(NodeMsg::Shutdown) => {
+                        log::info!("Shutdown requested, shutting down node");
+                        break;
+                    }
+                    Some(node_msg) => {
+                        node.handle_msg(node_msg).await;
+                    }
+                    None => {
+                        break;
+                    }
+                }
+            }
+        });
+
+        Ok(node_server_handle)
     }
 
-    fn set_client(&mut self, client: MasterClient) {
-        self.client = Some(client);
-    }
+    async fn handle_msg(&mut self, msg: NodeMsg) {
+        match msg {
+            NodeMsg::GetMasterUri { reply } => {
+                let _ = reply.send(self.client.get_master_uri().to_owned());
+            }
+            NodeMsg::GetSubscriptions { reply } => {
+                let _ = reply.send(
+                    self.subscriptions
+                        .iter()
+                        .map(|entry| (entry.key().clone(), entry.topic_type.clone()))
+                        .collect(),
+                );
+            }
+            NodeMsg::GetPublications { reply } => {
+                let _ = reply.send(
+                    self.publishers
+                        .iter()
+                        .map(|entry| (entry.key().clone(), entry.topic_type().to_owned()))
+                        .collect(),
+                );
+            }
+            NodeMsg::SetPeerPublishers { topic, publishers } => {
+                let item = self.subscriptions.get_mut(&topic);
+                let mut item = match item {
+                    Some(i) => i,
+                    None => {
+                        log::warn!("Got peer publisher update for topic we weren't subscribed to, ignoring");
+                        return;
+                    }
+                };
+                item.known_publishers = publishers;
+            }
+            NodeMsg::RegisterPublisher {
+                reply,
+                topic,
+                topic_type,
+                queue_size,
+                msg_definition,
+                md5sum,
+            } => {
+                let channel = match PublishingChannel::new(
+                    &self.node_name,
+                    false,
+                    &topic,
+                    self.host_addr,
+                    queue_size,
+                    &msg_definition,
+                    &md5sum,
+                    &topic_type,
+                )
+                .await
+                {
+                    Ok(channel) => channel,
+                    Err(err) => {
+                        let err_str = format!("Could not create publishing channel: {err:?}");
+                        log::error!("{err_str}");
+                        let _ = reply.send(Err(err_str));
+                        return;
+                    }
+                };
+                let pub_handle_sender = channel.get_sender();
+                self.publishers.insert(topic.clone(), channel);
 
-    pub(crate) fn get_master_uri(&self) -> String {
-        // Client is option due to connection loop issue, but always valid to unwrap
-        self.client.as_ref().unwrap().get_master_uri().to_string()
+                if let Ok(_current_subscribers) =
+                    self.client.register_publisher(&topic, &topic_type).await
+                {
+                    reply
+                        .send(Ok(pub_handle_sender))
+                        .expect("Failed to reply on oneshot");
+                } else {
+                    let err_str =
+                        format!("Failed to register publisher on topic {topic} with the rosmaster");
+                    format!("{err_str}");
+                    let _ = reply.send(Err(err_str));
+                }
+            }
+            NodeMsg::RequestTopic {
+                reply,
+                topic,
+                protocols,
+                ..
+            } => {
+                if protocols
+                    .iter()
+                    .find(|proto| proto.as_str() == "TCPROS")
+                    .is_some()
+                {
+                    if let Some(publishing_channel) = self
+                        .publishers
+                        .iter()
+                        .find(|publisher| publisher.key() == &topic)
+                    {
+                        let protocol_params = ProtocolParams {
+                            hostname: self.hostname.clone(),
+                            protocol: String::from("TCPROS"), // Hardcoded as the only option for now
+                            port: publishing_channel.port(),
+                        };
+                        let _ = reply.send(Ok(protocol_params));
+                    } else {
+                        let err_str = format!("Got request for topic {topic} from subscriber which this node does not publish");
+                        log::warn!("{err_str}");
+                        let _ = reply.send(Err(err_str));
+                    }
+                } else {
+                    let err_str = format!(
+                        "No supported protocols in the request from the subscriber: {protocols:?}"
+                    );
+                    log::error!("{err_str}");
+                    let _ = reply.send(Err(err_str));
+                }
+            }
+            NodeMsg::Shutdown => {
+                unreachable!("This node msg is handled in the wrapping handling code");
+            }
+        }
     }
 }
 
@@ -56,7 +355,7 @@ impl Node {
 /// This class provides the user facing API for interacting with ROS.
 #[derive(Clone)]
 pub struct NodeHandle {
-    pub(crate) inner: Arc<tokio::sync::RwLock<Node>>, // TODO we may be able to get away with no RwLock here?
+    inner: NodeServerHandle,
 }
 
 impl NodeHandle {
@@ -67,130 +366,77 @@ impl NodeHandle {
     pub async fn new(
         master_uri: &str,
         name: &str,
-    ) -> Result<NodeHandle, Box<dyn std::error::Error + Send + Sync>> {
-        // Create the central "Node" data record
-        let nh = NodeHandle {
-            inner: Arc::new(tokio::sync::RwLock::new(Node::new().await?)),
-        };
-
+    ) -> Result<NodeHandle, Box<dyn std::error::Error>> {
         // Follow ROS rules and determine our IP and hostname
-        let (addr, hostname) = Self::determine_addr()?;
+        let (addr, hostname) = determine_addr()?;
 
-        // Create our xmlrpc server and bind our socket so we know our port and can determine our local URI
-        let port = NodeServer::new(nh.clone(), addr);
-
-        let client_uri = format!("http://{hostname}:{port}");
-        let client = MasterClient::new(master_uri, client_uri, name).await?;
-        nh.inner.write().await.set_client(client);
+        let node = Node::new(master_uri, &hostname, name, addr).await?;
+        let nh = NodeHandle { inner: node };
 
         // TODO spawn our TcpManager here for TCPROS
 
         Ok(nh)
     }
 
-    // TODO at the end of the day I'd like to offer a builder pattern for configuration that allow manual setting of this or "ros idiomatic" behavior - Carter
-    /// Following ROS's idiomatic address rules uses ROS_HOSTNAME and ROS_IP to determine the address that server should be hosted at.
-    /// Returns both the resolved IpAddress of the host (used for actually opening the socket), and the String "hostname" which should
-    /// be used in the URI.
-    fn determine_addr() -> Result<(Ipv4Addr, String), RosMasterError> {
-        // If ROS_IP is set that trumps anything else
-        if let Ok(ip_str) = std::env::var("ROS_IP") {
-            let ip = ip_str.parse().map_err(|e| {
-                RosMasterError::HostIpResolutionFailure(format!(
-                    "ROS_IP environment variable did not parse to a valid IpAddr::V4: {e:?}"
-                ))
-            })?;
-            return Ok((ip, ip_str));
-        }
-        // If ROS_HOSTNAME is set that is next highest precedent
-        if let Ok(name) = std::env::var("ROS_HOSTNAME") {
-            let ip = Self::hostname_to_ipv4(&name)?;
-            return Ok((ip, name));
-        }
-        // If neither env var is set, use the computers "hostname"
-        let name = gethostname::gethostname();
-        let name = name.into_string().map_err(|e| {
-            RosMasterError::HostIpResolutionFailure(format!("This host's hostname is a string that cannot be validly converted into a Rust type, and therefore we cannot convert it into an IpAddrv4: {e:?}"))
-        })?;
-        let ip = Self::hostname_to_ipv4(&name)?;
-        return Ok((ip, name));
+    pub async fn advertise<T: roslibrust_codegen::RosMessageType>(
+        &self,
+        topic_name: &str,
+        queue_size: usize,
+    ) -> Result<Publisher<T>, Box<dyn std::error::Error>> {
+        let sender = self
+            .inner
+            .register_publisher::<T>(topic_name, T::ROS_TYPE_NAME, queue_size)
+            .await?;
+        Ok(Publisher::new(topic_name, sender))
     }
+}
 
-    /// Given a the name of a host use's std::net::ToSocketAddrs to perform a DNS lookup and return the resulting IP address.
-    /// This function is intended to be used to determine the correct IP host the socket for the xmlrpc server on.
-    fn hostname_to_ipv4(name: &str) -> Result<Ipv4Addr, RosMasterError> {
-        let mut i = (name, 0).to_socket_addrs().map_err(|e| {
+// TODO at the end of the day I'd like to offer a builder pattern for configuration that allow manual setting of this or "ros idiomatic" behavior - Carter
+/// Following ROS's idiomatic address rules uses ROS_HOSTNAME and ROS_IP to determine the address that server should be hosted at.
+/// Returns both the resolved IpAddress of the host (used for actually opening the socket), and the String "hostname" which should
+/// be used in the URI.
+fn determine_addr() -> Result<(Ipv4Addr, String), RosMasterError> {
+    // If ROS_IP is set that trumps anything else
+    if let Ok(ip_str) = std::env::var("ROS_IP") {
+        let ip = ip_str.parse().map_err(|e| {
             RosMasterError::HostIpResolutionFailure(format!(
-                "Failure while attempting to lookup ROS_HOSTNAME: {e:?}"
+                "ROS_IP environment variable did not parse to a valid IpAddr::V4: {e:?}"
             ))
         })?;
-        if let Some(addr) = i.next() {
-            match addr.ip() {
+        return Ok((ip, ip_str));
+    }
+    // If ROS_HOSTNAME is set that is next highest precedent
+    if let Ok(name) = std::env::var("ROS_HOSTNAME") {
+        let ip = hostname_to_ipv4(&name)?;
+        return Ok((ip, name));
+    }
+    // If neither env var is set, use the computers "hostname"
+    let name = gethostname::gethostname();
+    let name = name.into_string().map_err(|e| {
+            RosMasterError::HostIpResolutionFailure(format!("This host's hostname is a string that cannot be validly converted into a Rust type, and therefore we cannot convert it into an IpAddrv4: {e:?}"))
+        })?;
+    let ip = hostname_to_ipv4(&name)?;
+    return Ok((ip, name));
+}
+
+/// Given a the name of a host use's std::net::ToSocketAddrs to perform a DNS lookup and return the resulting IP address.
+/// This function is intended to be used to determine the correct IP host the socket for the xmlrpc server on.
+fn hostname_to_ipv4(name: &str) -> Result<Ipv4Addr, RosMasterError> {
+    let mut i = (name, 0).to_socket_addrs().map_err(|e| {
+        RosMasterError::HostIpResolutionFailure(format!(
+            "Failure while attempting to lookup ROS_HOSTNAME: {e:?}"
+        ))
+    })?;
+    if let Some(addr) = i.next() {
+        match addr.ip() {
                 IpAddr::V4(ip) => Ok(ip),
                 IpAddr::V6(ip) => {
                     Err(RosMasterError::HostIpResolutionFailure(format!("ROS_HOSTNAME resolved to an IPv6 address which is not support by ROS/roslibrust: {ip:?}")))
                 }
             }
-        } else {
-            Err(RosMasterError::HostIpResolutionFailure(format!(
-                "ROS_HOSTNAME did not resolve any address: {name:?}"
-            )))
-        }
-    }
-
-    // TODO pub vs. pub(crate)
-    /// Gets the URI at which this node is hosting its xmlrpc server
-    pub async fn get_client_uri(&self) -> String {
-        self.inner
-            .read()
-            .await
-            .client
-            .as_ref()
-            .unwrap()
-            .client_uri()
-            .to_string()
-    }
-
-    // TODO pub vs. pub(crate)
-    /// Gets the list of topics the node is currently subscribed to.
-    /// Returns a tuple of (Topic Name, Topic Type) e.g. ("/rosout", "rosgraph_msgs/Log").
-    pub async fn get_subscriptions(&self) -> Vec<(String, String)> {
-        self.inner
-            .read()
-            .await
-            .subscriptions
-            .iter()
-            .map(|entry| (entry.key().clone(), entry.topic_type.clone()))
-            .collect()
-    }
-
-    /// Gets the list of topic the node is currently publishing to.
-    /// Returns a tuple of (Topic Name, Topic Type) e.g. ("/rosout", "rosgraph_msgs/Log").
-    pub async fn get_publications(&self) -> Vec<(String, String)> {
-        self.inner
-            .read()
-            .await
-            .publishers
-            .iter()
-            .map(|entry| (entry.key().clone(), entry.topic_type.clone()))
-            .collect()
-    }
-
-    /// Updates the list of know publishers for a given topic
-    /// This is used to know who to reach out to for updates
-    /// TODO this kind of update flow could probably be done better with a channel, for now sticking info
-    /// into a DashMap cause I think it will be easier to debug
-    pub(crate) async fn set_peer_publishers(&self, topic: String, publishers: Vec<String>) {
-        let lock = self.inner.read().await;
-        let item = lock.subscriptions.get_mut(&topic);
-        let mut item = match item {
-            Some(i) => i,
-            None => {
-                warn!("Got peer publisher update for topic we weren't subscribed to, ignoring");
-                return;
-            }
-        };
-        // Update our internal list of known publishers
-        item.known_publishers = publishers;
+    } else {
+        Err(RosMasterError::HostIpResolutionFailure(format!(
+            "ROS_HOSTNAME did not resolve any address: {name:?}"
+        )))
     }
 }

--- a/roslibrust/src/ros1/node.rs
+++ b/roslibrust/src/ros1/node.rs
@@ -124,6 +124,13 @@ impl NodeServerHandle {
             .map_err(|err| Box::new(err))?)
     }
 
+    pub fn shutdown(&self) -> Result<(), Box<dyn std::error::Error>> {
+        self.node_server_sender
+            .send(NodeMsg::Shutdown)
+            .map_err(|err| Box::new(err))?;
+        Ok(())
+    }
+
     pub async fn register_publisher<T: RosMessageType>(
         &self,
         topic: &str,
@@ -392,6 +399,10 @@ impl NodeHandle {
         // TODO spawn our TcpManager here for TCPROS
 
         Ok(nh)
+    }
+
+    pub fn is_ok(&self) -> bool {
+        !self.inner.node_server_sender.is_closed()
     }
 
     pub async fn get_client_uri(&self) -> Result<String, Box<dyn std::error::Error>> {

--- a/roslibrust/src/ros1/node.rs
+++ b/roslibrust/src/ros1/node.rs
@@ -3,8 +3,7 @@
 
 use super::publisher::{Publisher, PublishingChannel};
 use crate::{
-    MasterClient, PublisherHandle, RosMasterError, ServiceCallback, Subscription, XmlRpcServer,
-    XmlRpcServerHandle,
+    MasterClient, RosMasterError, ServiceCallback, Subscription, XmlRpcServer, XmlRpcServerHandle,
 };
 use dashmap::DashMap;
 use roslibrust_codegen::RosMessageType;

--- a/roslibrust/src/ros1/publisher.rs
+++ b/roslibrust/src/ros1/publisher.rs
@@ -1,0 +1,156 @@
+use super::tcpros::ConnectionHeader;
+use abort_on_drop::ChildTask;
+use roslibrust_codegen::RosMessageType;
+use std::{
+    marker::PhantomData,
+    net::{Ipv4Addr, SocketAddr},
+    sync::Arc,
+};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    sync::{mpsc, RwLock},
+};
+
+pub struct Publisher<T> {
+    topic_name: String,
+    sender: mpsc::Sender<Vec<u8>>,
+    phantom: PhantomData<T>,
+}
+
+impl<T: RosMessageType> Publisher<T> {
+    pub(crate) fn new(topic_name: &str, sender: mpsc::Sender<Vec<u8>>) -> Self {
+        Self {
+            topic_name: topic_name.to_owned(),
+            sender,
+            phantom: PhantomData,
+        }
+    }
+
+    pub async fn publish(&self, data: &T) -> Result<(), Box<dyn std::error::Error>> {
+        let data = serde_rosmsg::to_vec(&data)?;
+        self.sender.send(data).await?;
+        Ok(())
+    }
+}
+
+pub struct PublishingChannel {
+    topic_type: String,
+    listener_port: u16,
+    _channel_task: ChildTask<()>,
+    _publish_task: ChildTask<()>,
+    publish_sender: mpsc::Sender<Vec<u8>>,
+}
+
+impl PublishingChannel {
+    pub async fn new(
+        node_name: &str,
+        latching: bool,
+        topic_name: &str,
+        host_addr: Ipv4Addr,
+        queue_size: usize,
+        msg_definition: &str,
+        md5sum: &str,
+        topic_type: &str,
+    ) -> Result<Self, std::io::Error> {
+        let host_addr = SocketAddr::from((host_addr, 0));
+        let tcp_listener = tokio::net::TcpListener::bind(host_addr).await?;
+        let listener_port = tcp_listener.local_addr().unwrap().port();
+
+        let (sender, mut receiver) = mpsc::channel::<Vec<u8>>(queue_size);
+
+        let responding_conn_header = ConnectionHeader {
+            caller_id: node_name.to_owned(),
+            latching,
+            msg_definition: msg_definition.to_owned(),
+            md5sum: md5sum.to_owned(),
+            topic: topic_name.to_owned(),
+            topic_type: topic_type.to_owned(),
+            tcp_nodelay: false,
+        };
+
+        let subscriber_streams = Arc::new(RwLock::new(Vec::new()));
+
+        let subscriber_streams_copy = subscriber_streams.clone();
+        let listener_handle = tokio::spawn(async move {
+            let subscriber_streams = subscriber_streams_copy;
+            loop {
+                if let Ok((mut stream, peer_addr)) = tcp_listener.accept().await {
+                    let topic_name = responding_conn_header.topic.as_str();
+                    log::info!(
+                        "Received connection from subscriber at {peer_addr} for topic {topic_name}"
+                    );
+                    let mut connection_header = Vec::with_capacity(16 * 1024);
+                    if let Ok(bytes) = stream.read_buf(&mut connection_header).await {
+                        if let Ok(connection_header) =
+                            ConnectionHeader::from_bytes(&connection_header[..bytes])
+                        {
+                            if connection_header.md5sum == responding_conn_header.md5sum {
+                                log::debug!(
+                                    "Received subscribe request for {}",
+                                    connection_header.topic
+                                );
+                                // Write our own connection header in response
+                                let response_header_bytes = responding_conn_header
+                                    .to_bytes(false)
+                                    .expect("Couldn't serialize connection header");
+                                stream
+                                    .write(&response_header_bytes[..])
+                                    .await
+                                    .expect("Unable to respond on tcpstream");
+                                let mut wlock = subscriber_streams.write().await;
+                                wlock.push(stream);
+                            }
+                        } else {
+                            let header_str = connection_header[..bytes]
+                                .into_iter()
+                                .map(|ch| if *ch < 128 { *ch as char } else { '.' })
+                                .collect::<String>();
+                            log::error!(
+                                "Failed to parse connection header: ({bytes} bytes) {header_str}",
+                            )
+                        }
+                    }
+                }
+            }
+        });
+
+        let publish_task = tokio::spawn(async move {
+            loop {
+                match receiver.recv().await {
+                    Some(msg_to_publish) => {
+                        let mut streams = subscriber_streams.write().await;
+                        for stream in streams.iter_mut() {
+                            if let Err(err) = stream.write(&msg_to_publish[..]).await {
+                                log::error!("Failed to send data to subscriber: {err:?}");
+                            }
+                        }
+                    }
+                    None => {
+                        log::debug!("No more senders for the publisher channel, exiting...");
+                        break;
+                    }
+                }
+            }
+        });
+
+        Ok(Self {
+            topic_type: topic_type.to_owned(),
+            _channel_task: listener_handle.into(),
+            listener_port,
+            publish_sender: sender,
+            _publish_task: publish_task.into(),
+        })
+    }
+
+    pub fn get_sender(&self) -> mpsc::Sender<Vec<u8>> {
+        self.publish_sender.clone()
+    }
+
+    pub fn port(&self) -> u16 {
+        self.listener_port
+    }
+
+    pub fn topic_type(&self) -> &str {
+        &self.topic_type
+    }
+}

--- a/roslibrust/src/ros1/tcpros.rs
+++ b/roslibrust/src/ros1/tcpros.rs
@@ -1,0 +1,117 @@
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use std::io::{Cursor, Read, Write};
+
+pub struct ConnectionHeader {
+    pub caller_id: String,
+    pub latching: bool,
+    pub msg_definition: String,
+    pub md5sum: String,
+    pub topic: String,
+    pub topic_type: String,
+    pub tcp_nodelay: bool,
+}
+
+impl ConnectionHeader {
+    pub fn from_bytes(header_data: &[u8]) -> std::io::Result<ConnectionHeader> {
+        let mut cursor = Cursor::new(header_data);
+        let header_length = cursor.read_u32::<LittleEndian>()?;
+        if header_length as usize > header_data.len() {
+            return Err(std::io::ErrorKind::InvalidInput.into());
+        }
+
+        let mut msg_definition = String::new();
+        let mut caller_id = String::new();
+        let mut latching = false;
+        let mut md5sum = String::new();
+        let mut topic = String::new();
+        let mut topic_type = String::new();
+        let mut tcp_nodelay = false;
+
+        // TODO: Unhandled: error, persistent
+
+        while cursor.position() < header_data.len() as u64 {
+            let field_length = cursor.read_u32::<LittleEndian>()? as usize;
+            let mut field = vec![0u8; field_length];
+            cursor.read_exact(&mut field)?;
+            let field = String::from_utf8(field).unwrap();
+            let equals_pos = match field.find('=') {
+                Some(pos) => pos,
+                None => continue,
+            };
+            if field.starts_with("message_definition=") {
+                field[equals_pos + 1..].clone_into(&mut msg_definition);
+            } else if field.starts_with("callerid=") {
+                field[equals_pos + 1..].clone_into(&mut caller_id);
+            } else if field.starts_with("latching=") {
+                let mut latching_str = String::new();
+                field[equals_pos + 1..].clone_into(&mut latching_str);
+                latching = &latching_str != "0";
+            } else if field.starts_with("md5sum=") {
+                field[equals_pos + 1..].clone_into(&mut md5sum);
+            } else if field.starts_with("topic=") {
+                field[equals_pos + 1..].clone_into(&mut topic);
+            } else if field.starts_with("type=") {
+                field[equals_pos + 1..].clone_into(&mut topic_type);
+            } else if field.starts_with("tcp_nodelay=") {
+                let mut tcp_nodelay_str = String::new();
+                field[equals_pos + 1..].clone_into(&mut tcp_nodelay_str);
+                tcp_nodelay = &tcp_nodelay_str != "0";
+            } else {
+                log::warn!("Encountered unhandled field in connection header: {field}");
+            }
+        }
+
+        Ok(ConnectionHeader {
+            caller_id,
+            latching,
+            msg_definition,
+            md5sum,
+            topic,
+            topic_type,
+            tcp_nodelay,
+        })
+    }
+
+    pub fn to_bytes(&self, to_publisher: bool) -> std::io::Result<Vec<u8>> {
+        let mut header_data = Vec::with_capacity(1024);
+        // Start by skipping the length header since we don't know yet
+        header_data.write_u32::<LittleEndian>(0)?;
+
+        let caller_id_str = format!("caller_id={}", self.caller_id);
+        header_data.write_u32::<LittleEndian>(caller_id_str.len() as u32)?;
+        header_data.write(caller_id_str.as_bytes())?;
+
+        let latching_str = format!("latching={}", if self.latching { 1 } else { 0 });
+        header_data.write_u32::<LittleEndian>(latching_str.len() as u32)?;
+        header_data.write(latching_str.as_bytes())?;
+
+        let md5sum = format!("md5sum={}", self.md5sum);
+        header_data.write_u32::<LittleEndian>(md5sum.len() as u32)?;
+        header_data.write(md5sum.as_bytes())?;
+
+        let msg_definition = format!("message_definition={}", self.msg_definition);
+        header_data.write_u32::<LittleEndian>(msg_definition.len() as u32)?;
+        header_data.write(msg_definition.as_bytes())?;
+
+        if to_publisher {
+            let tcp_nodelay = format!("tcp_nodelay={}", if self.tcp_nodelay { 1 } else { 0 });
+            header_data.write_u32::<LittleEndian>(tcp_nodelay.len() as u32)?;
+            header_data.write(tcp_nodelay.as_bytes())?;
+        }
+
+        let topic = format!("topic={}", self.topic);
+        header_data.write_u32::<LittleEndian>(topic.len() as u32)?;
+        header_data.write(topic.as_bytes())?;
+
+        let topic_type = format!("type={}", self.topic_type);
+        header_data.write_u32::<LittleEndian>(topic_type.len() as u32)?;
+        header_data.write(topic_type.as_bytes())?;
+
+        let total_length = (header_data.len() - 4) as u32;
+        for (idx, byte) in total_length.to_le_bytes().iter().enumerate() {
+            header_data[idx] = *byte;
+        }
+
+        Ok(header_data)
+    }
+}

--- a/roslibrust/src/ros1/tcpros.rs
+++ b/roslibrust/src/ros1/tcpros.rs
@@ -1,6 +1,8 @@
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use std::io::{Cursor, Read, Write};
 
+// Implementation of ConnectionHeader is based off of ROS documentation here:
+// wiki.ros.org/ROS/Connection%20Header
 pub struct ConnectionHeader {
     pub caller_id: String,
     pub latching: bool,

--- a/roslibrust/src/ros1/xmlrpc_server.rs
+++ b/roslibrust/src/ros1/xmlrpc_server.rs
@@ -7,6 +7,7 @@ use std::{
     net::{Ipv4Addr, SocketAddr},
 };
 
+#[allow(unused)]
 enum RosXmlStatusCode {
     Error,
     Failure,
@@ -312,96 +313,5 @@ impl XmlRpcServer {
             Ok(body) => Ok(body),
             Err(body) => Ok(body),
         }
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use log::debug;
-    use serde::de::DeserializeOwned;
-    use serde_xmlrpc::Value;
-
-    use crate::NodeHandle;
-
-    // Helper function for making a call to one of the node server apis
-    async fn call_node_server<T: DeserializeOwned>(
-        uri: &str,
-        endpoint: &str,
-        args: Vec<Value>,
-    ) -> T {
-        let client = reqwest::Client::new();
-        let body = serde_xmlrpc::request_to_string(endpoint, args).unwrap();
-        let res = client
-            .post(uri)
-            .body(body)
-            .send()
-            .await
-            .unwrap()
-            .text()
-            .await
-            .unwrap();
-        debug!("Got response: {res:?}");
-        let (error_code, debug_str, value): (i8, String, T) =
-            serde_xmlrpc::response_from_str(&res).unwrap();
-
-        assert_eq!(error_code, 0);
-        assert_eq!(debug_str, "");
-        value
-    }
-
-    #[test_log::test(tokio::test)]
-    async fn test_get_master_uri() {
-        let nh = NodeHandle::new("http://localhost:11311", "/get_master_uri_test_node")
-            .await
-            .unwrap();
-        let client_uri = nh.get_master_uri().await;
-
-        let uri: String = call_node_server(
-            &client_uri,
-            "getMasterUri",
-            vec!["/get_master_uri_tester".into()],
-        )
-        .await;
-        assert_eq!(uri, "http://localhost:11311");
-    }
-
-    #[test_log::test(tokio::test)]
-    async fn test_get_subscriptions() {
-        // Stub test until we can actually subscribe
-        let nh = NodeHandle::new("http://localhost:11311", "/get_subscriptions_test_node")
-            .await
-            .unwrap();
-        let client_uri = nh.get_client_uri().await;
-
-        // TODO actually subscribe here
-
-        let subs: Vec<(String, String)> = call_node_server(
-            &client_uri,
-            "getSubscriptions",
-            vec!["/get_subscriptions_tester".into()],
-        )
-        .await;
-
-        // TODO assert we get our subscription back here
-    }
-
-    #[test_log::test(tokio::test)]
-    async fn test_get_publications() {
-        // Stub test until we can actually advertise
-        let nh = NodeHandle::new("http://localhost:11311", "/get_subscriptions_test_node")
-            .await
-            .unwrap();
-        let client_uri = nh.get_client_uri().await;
-
-        // TODO actually advertise here
-
-        let pubs: Vec<(String, String)> = call_node_server(
-            &client_uri,
-            "getPublications",
-            vec!["/get_publications_tester".into()],
-        )
-        .await;
-
-        // TODO assert we get our publication back here
     }
 }

--- a/roslibrust/src/ros1/xmlrpc_server.rs
+++ b/roslibrust/src/ros1/xmlrpc_server.rs
@@ -1,55 +1,83 @@
+use super::node::NodeServerHandle;
+use abort_on_drop::ChildTask;
+use hyper::{Body, Response, StatusCode};
+use log::*;
 use std::{
     convert::Infallible,
     net::{Ipv4Addr, SocketAddr},
 };
 
-use hyper::{Body, Response, StatusCode};
-use log::*;
+enum RosXmlStatusCode {
+    Error,
+    Failure,
+    Success,
+    Other(i32),
+}
 
-use crate::NodeHandle;
+impl RosXmlStatusCode {
+    pub fn code(&self) -> i32 {
+        match self {
+            RosXmlStatusCode::Error => -1,
+            RosXmlStatusCode::Failure => 0,
+            RosXmlStatusCode::Success => 1,
+            RosXmlStatusCode::Other(code) => *code,
+        }
+    }
+}
 
 /// Hosts an xmlrpc API that rosmaster will call to notify of new subscribers / publishers etc.
 /// Is also called by other ros nodes to initiate point to point connections.
 /// Note: ROS uses "master/slave" terminology here. We continue to refer to the ROS central server as the ROS master,
-/// but are intentionally using "NodeServer" in place of where ROS says "Slave API"
-pub(crate) struct NodeServer {}
+/// but are intentionally using "XmlRpcServer" in place of where ROS says "Slave API"
+pub(crate) struct XmlRpcServer {}
 
-impl NodeServer {
-    // Creates a new node server and starts it running
-    // Returns a join handle used to indicate if the server stops running, and the port the server bound to
-    pub(crate) fn new(handle: NodeHandle, host_addr: Ipv4Addr) -> u16 {
-        let host_addr = SocketAddr::from((host_addr, 0));
+pub(crate) struct XmlRpcServerHandle {
+    port: u16,
+    _handle: ChildTask<()>,
+}
 
+impl XmlRpcServerHandle {
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+}
+
+impl XmlRpcServer {
+    pub fn new(host_addr: Ipv4Addr, node_server: NodeServerHandle) -> XmlRpcServerHandle {
         let make_svc = hyper::service::make_service_fn(move |connection| {
             debug!("New node xmlrpc connection {connection:?}");
-            let handle = handle.clone(); // Make a unique handle for each connection
+            let node_server = node_server.clone();
             async move {
                 Ok::<_, Infallible>(hyper::service::service_fn(move |req| {
-                    let handle = handle.clone(); // Each call gets their own copy of the handle too
-                    NodeServer::respond(handle, req)
+                    XmlRpcServer::respond(node_server.clone(), req)
                 }))
             }
         });
-
+        let host_addr = SocketAddr::from((host_addr, 0));
         let server = hyper::server::Server::bind(&host_addr.into());
         let server = server.serve(make_svc);
         let addr = server.local_addr();
 
-        tokio::spawn(async move {
-            let x = server.await;
-            error!("Node's xmlrpc server was stopped unexpectedly: {x:?}");
+        let handle = tokio::spawn(async {
+            if let Err(err) = server.await {
+                log::error!("xmlrpc server encountered error: {err:?}");
+            }
         });
-        addr.port()
+
+        XmlRpcServerHandle {
+            port: addr.port(),
+            _handle: handle.into(),
+        }
     }
 
     // Our actual service handler with our error type
     async fn respond_inner(
-        handle: NodeHandle,
+        node_server: NodeServerHandle,
         body: hyper::Request<Body>,
     ) -> Result<Response<Body>, Response<Body>> {
         // Await the bytes of the body
         let body = hyper::body::to_bytes(body).await.map_err(|e| {
-            Self::error_mapper(
+            Self::make_error_response(
                 e,
                 "Failed to get bytes from http request on xmlrpc server, request ignored",
                 StatusCode::BAD_REQUEST,
@@ -58,7 +86,7 @@ impl NodeServer {
 
         // Parse as string
         let body = String::from_utf8(body.to_vec()).map_err(|e| {
-            Self::error_mapper(
+            Self::make_error_response(
                 e,
                 "Failed to parse http body as valid utf8 string, request ignored",
                 StatusCode::BAD_REQUEST,
@@ -67,7 +95,7 @@ impl NodeServer {
 
         // Parse as xmlrpc request
         let (method_name, args) = serde_xmlrpc::request_from_str(&body).map_err(|e| {
-            Self::error_mapper(
+            Self::make_error_response(
                 e,
                 "Failed to parse valid xmlrpc method request out of body, request ignored",
                 StatusCode::BAD_REQUEST,
@@ -78,39 +106,51 @@ impl NodeServer {
         match method_name.as_str() {
             "getMasterUri" => {
                 debug!("getMasterUri called by {args:?}");
-                let lock = handle.inner.read().await;
-                let uri = lock.get_master_uri();
-                Self::to_response(uri)
+                match node_server.get_master_uri().await {
+                    Ok(uri) => Self::to_response(uri),
+                    Err(e) => Err(Self::make_response_from_boxed_error(
+                        e,
+                        "Unable to retrieve master URI",
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                    )),
+                }
             }
             "getPid" => {
                 debug!("getPid called by {args:?}");
                 let pid = std::process::id();
                 let pid: i32 = pid.try_into().map_err(|e| {
-                    Self::error_mapper(e,
+                    Self::make_error_response(e,
                          "Operation system returned a PID which does not fit into i32, and therefor cannot be sent via xmlrpc",
                          StatusCode::INTERNAL_SERVER_ERROR)})?;
                 Self::to_response(pid)
             }
             "getSubscriptions" => {
                 debug!("getSubscriptions called by {args:?}");
-                let subs = handle.get_subscriptions().await;
-                // Have to manually convert to value because of Vec specialization
-                let subs = serde_xmlrpc::to_value(subs).map_err(|e| {
-                    Self::error_mapper(
-                        e,
-                        "Subscriptions contained names which could not be validly serialized to xmlrpc",
-                        StatusCode::INTERNAL_SERVER_ERROR)})?;
-                Self::to_response(subs)
+                match node_server.get_subscriptions().await {
+                    Ok(subs) => {
+                        match serde_xmlrpc::to_value(subs) {
+                            Ok(subs) => Self::to_response(subs),
+                            Err(e) => Err(Self::make_error_response(
+                                e,
+                                "Subscriptions contained names which could not be validly serialized to xmlrpc",
+                                StatusCode::INTERNAL_SERVER_ERROR))
+                        }
+                    },
+                    Err(e) => Err(Self::make_response_from_boxed_error(e, "Unable to get subscriptions", StatusCode::INTERNAL_SERVER_ERROR))
+                }
             }
             "getPublications" => {
                 debug!("getPublications called by {args:?}");
-                let pubs = handle.get_publications().await;
-                let pubs = serde_xmlrpc::to_value(pubs).map_err(|e| {
-                    Self::error_mapper(
-                        e,
-                        "Publications contained names which could not be validly serialized to xmlrpc",
-                        StatusCode::INTERNAL_SERVER_ERROR)})?;
-                Self::to_response(pubs)
+                match node_server.get_publications().await {
+                    Ok(pubs) => match serde_xmlrpc::to_value(pubs) {
+                        Ok(pubs) => Self::to_response(pubs),
+                        Err(e) => Err(Self::make_error_response(
+                            e,
+                            "Publications contained names which could not be validly serialized to xmlrpc",
+                            StatusCode::INTERNAL_SERVER_ERROR))
+                    },
+                    Err(e) => Err(Self::make_response_from_boxed_error(e, "Unable to get publications", StatusCode::INTERNAL_SERVER_ERROR))
+                }
             }
             "paramUpdate" => {
                 // Not supporting params for first cut
@@ -121,21 +161,57 @@ impl NodeServer {
                 debug!("publisherUpdate called by {args:?}");
                 let (_caller_id, topic, publishers): (String, String, Vec<String>) =
                     serde_xmlrpc::from_values(args).map_err(|e| {
-                        Self::error_mapper(
+                        Self::make_error_response(
                             e,
                             "Failed to parse arguments to publisherUpdate",
                             StatusCode::BAD_REQUEST,
                         )
                     })?;
-
-                handle.set_peer_publishers(topic, publishers).await;
+                node_server
+                    .set_peer_publishers(topic, publishers)
+                    .map_err(|e| {
+                        Self::make_response_from_boxed_error(
+                            e,
+                            "Unable to set peer publishers",
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                        )
+                    })?;
 
                 // ROS's API is for us to still return an int, but the value is literally named "ignore"...
                 Self::to_response(0)
             }
             "requestTopic" => {
                 debug!("requestTopic called by {args:?}");
-                unimplemented!()
+                let (caller_id, topic, protocols): (String, String, Vec<Vec<String>>) =
+                    serde_xmlrpc::from_values(args).map_err(|e| {
+                        Self::make_error_response(
+                            e,
+                            "Failed to parse arguments to requestTopic",
+                            StatusCode::BAD_REQUEST,
+                        )
+                    })?;
+                let protocols = protocols.iter().flatten().cloned().collect::<Vec<_>>();
+                debug!("Request for topic {topic} from {caller_id} via protocols {protocols:?}");
+                let params = node_server
+                    .request_topic(&caller_id, &topic, &protocols)
+                    .await
+                    .map_err(|e| {
+                        Self::make_response_from_boxed_error(
+                            e,
+                            "Unable to get parameters for requested topic",
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                        )
+                    })?;
+
+                let response = Self::make_success_response(
+                    RosXmlStatusCode::Success,
+                    format!("ready on {}:{}", params.hostname.clone(), params.port).as_str(),
+                    serde_xmlrpc::to_value((params.protocol, params.hostname, params.port))
+                        .unwrap(),
+                );
+
+                log::debug!("Sending response for requested topic {response:?}");
+                Ok(response)
             }
             // getBusStats, getBusInfo <= have decided not to impl these
             _ => {
@@ -149,18 +225,43 @@ impl NodeServer {
         }
     }
 
+    fn make_success_response(
+        status_code: RosXmlStatusCode,
+        status_msg: &str,
+        value: serde_xmlrpc::Value,
+    ) -> Response<Body> {
+        match serde_xmlrpc::response_to_string(
+            vec![serde_xmlrpc::Value::Array(vec![
+                status_code.code().into(),
+                status_msg.into(),
+                value,
+            ])]
+            .into_iter(),
+        ) {
+            Ok(body) => Response::builder()
+                .status(StatusCode::OK)
+                .body(Body::from(body))
+                .unwrap(),
+            Err(err) => Self::make_error_response(
+                err,
+                "Failed to serialize response data into valid xml",
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ),
+        }
+    }
+
     // Helper function for converting serde_xmlrpc stuff into responses
     fn to_response(v: impl Into<serde_xmlrpc::Value>) -> Result<Response<Body>, Response<Body>> {
         serde_xmlrpc::response_to_string(
             vec![serde_xmlrpc::Value::Array(vec![
-                0.into(),
+                1.into(),
                 "".into(),
                 v.into(),
             ])]
             .into_iter(),
         )
         .map_err(|e| {
-            Self::error_mapper(
+            Self::make_error_response(
                 e,
                 "Failed to serialize response data into valid xml",
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -175,8 +276,21 @@ impl NodeServer {
     }
 
     // Helper function for converting error to http responses
-    fn error_mapper(
+    fn make_error_response(
         e: impl std::error::Error,
+        msg: &str,
+        code: hyper::http::StatusCode,
+    ) -> Response<Body> {
+        let error_msg = format!("{msg}: {e:?}");
+        warn!("{error_msg}");
+        Response::builder()
+            .status(code)
+            .body(Body::from(error_msg))
+            .unwrap()
+    }
+
+    fn make_response_from_boxed_error(
+        e: Box<dyn std::error::Error>,
         msg: &str,
         code: hyper::http::StatusCode,
     ) -> Response<Body> {
@@ -190,11 +304,11 @@ impl NodeServer {
 
     // Is the actual function we hand to hyper
     async fn respond(
-        handle: NodeHandle,
+        node_server: NodeServerHandle,
         body: hyper::Request<Body>,
     ) -> Result<Response<Body>, Infallible> {
         // Call our inner function and unwrap error type into response
-        match Self::respond_inner(handle, body).await {
+        match Self::respond_inner(node_server, body).await {
             Ok(body) => Ok(body),
             Err(body) => Ok(body),
         }
@@ -240,7 +354,7 @@ mod test {
         let nh = NodeHandle::new("http://localhost:11311", "/get_master_uri_test_node")
             .await
             .unwrap();
-        let client_uri = nh.get_client_uri().await;
+        let client_uri = nh.get_master_uri().await;
 
         let uri: String = call_node_server(
             &client_uri,

--- a/roslibrust/tests/ros1_xmlrpc.rs
+++ b/roslibrust/tests/ros1_xmlrpc.rs
@@ -54,4 +54,22 @@ mod tests {
         .await;
         assert_eq!(publications.len(), 0);
     }
+
+    #[tokio::test]
+    async fn verify_shutdown() {
+        let node = roslibrust::NodeHandle::new("http://localhost:11311", "verify_shutdown")
+            .await
+            .unwrap();
+        let node_uri = node.get_client_uri().await.unwrap();
+        assert!(node.is_ok());
+
+        call_node_api::<i32>(
+            &node_uri,
+            "shutdown",
+            vec!["/verify_shutdown".into(), "".into()],
+        )
+        .await;
+
+        assert!(!node.is_ok());
+    }
 }

--- a/roslibrust/tests/ros1_xmlrpc.rs
+++ b/roslibrust/tests/ros1_xmlrpc.rs
@@ -1,0 +1,57 @@
+#[cfg(all(feature = "ros1", feature = "ros1_test"))]
+mod tests {
+    use serde::de::DeserializeOwned;
+    use serde_xmlrpc::Value;
+
+    async fn call_node_api<T: DeserializeOwned>(uri: &str, endpoint: &str, args: Vec<Value>) -> T {
+        let client = reqwest::Client::new();
+        let body = serde_xmlrpc::request_to_string(endpoint, args).unwrap();
+        let response = client
+            .post(uri)
+            .body(body)
+            .send()
+            .await
+            .unwrap()
+            .text()
+            .await
+            .unwrap();
+        let (error_code, error_description, value): (i8, String, T) =
+            serde_xmlrpc::response_from_str(&response).unwrap();
+
+        assert_eq!(error_code, 1);
+        assert_eq!(error_description.len(), 0);
+        value
+    }
+
+    #[tokio::test]
+    async fn verify_get_master_uri() {
+        let node = roslibrust::NodeHandle::new("http://localhost:11311", "verify_get_master_uri")
+            .await
+            .unwrap();
+        let node_uri = node.get_client_uri().await.unwrap();
+
+        let master_uri = call_node_api::<String>(
+            &node_uri,
+            "getMasterUri",
+            vec!["/get_master_uri_test".into()],
+        )
+        .await;
+        assert_eq!(master_uri, "http://localhost:11311");
+    }
+
+    #[tokio::test]
+    async fn verify_get_publications() {
+        let node = roslibrust::NodeHandle::new("http://localhost:11311", "verify_get_publications")
+            .await
+            .unwrap();
+        let node_uri = node.get_client_uri().await.unwrap();
+
+        let publications = call_node_api::<Vec<(String, String)>>(
+            &node_uri,
+            "getPublications",
+            vec!["/verify_get_publications".into()],
+        )
+        .await;
+        assert_eq!(publications.len(), 0);
+    }
+}

--- a/roslibrust_codegen/src/lib.rs
+++ b/roslibrust_codegen/src/lib.rs
@@ -134,15 +134,12 @@ impl MessageFile {
             if is_intrinsic_type(parsed.version.unwrap_or(RosVersion::ROS1), field_type) {
                 md5sum_content.push_str(&format!("{} {}\n", field.field_type, field.field_name));
             } else {
-                let field_full_name = format!(
-                    "{}/{}",
-                    field
-                        .field_type
-                        .package_name
-                        .as_ref()
-                        .unwrap_or_else(|| panic!("Expected package name for field {field:#?}")),
-                    field_type
-                );
+                let field_package = field
+                    .field_type
+                    .package_name
+                    .as_ref()
+                    .expect(&format!("Expected package name for field {field:#?}"));
+                let field_full_name = format!("{field_package}/{field_type}");
                 let sub_message = graph.get(field_full_name.as_str())?;
                 let sub_md5sum = Self::compute_md5sum(&sub_message.parsed, graph)?;
                 md5sum_content.push_str(&format!("{} {}\n", sub_md5sum, field.field_name));
@@ -310,14 +307,12 @@ impl PartialEq for FieldInfo {
 
 impl FieldInfo {
     pub fn get_full_name(&self) -> String {
-        format!(
-            "{}/{}",
-            self.field_type
-                .package_name
-                .as_ref()
-                .unwrap_or_else(|| panic!("Expected package name for field {self:#?}")),
-            self.field_type.field_type
-        )
+        let field_package = self
+            .field_type
+            .package_name
+            .as_ref()
+            .expect(&format!("Expected package name for field {self:#?}"));
+        format!("{field_package}/{}", self.field_type.field_type)
     }
 }
 


### PR DESCRIPTION
Alright! So this has numerous issues; it will explode if you look at it wrong, but I successfully got the `ros1_talker` example to publish data to the listener node from the ROS1 tutorial: https://github.com/ros/ros_tutorials/blob/noetic-devel/rospy_tutorials/001_talker_listener/listener.py

Output from the listener node
```
demo_nodes-talker_listener-1  | [INFO] [1693161083.219396]: /listenerI heard hello world from rust 322
demo_nodes-talker_listener-1  | [INFO] [1693161084.220899]: /listenerI heard hello world from rust 323
demo_nodes-talker_listener-1  | [INFO] [1693161085.222399]: /listenerI heard hello world from rust 324
demo_nodes-talker_listener-1  | [INFO] [1693161086.227722]: /listenerI heard hello world from rust 325
demo_nodes-talker_listener-1  | [INFO] [1693161087.228721]: /listenerI heard hello world from rust 326
demo_nodes-talker_listener-1  | [INFO] [1693161088.231114]: /listenerI heard hello world from rust 327
demo_nodes-talker_listener-1  | [INFO] [1693161089.233616]: /listenerI heard hello world from rust 328
demo_nodes-talker_listener-1  | [INFO] [1693161090.235346]: /listenerI heard hello world from rust 329
```

Log output from the `ros1_talker` example
```
DEBUG [reqwest::connect] starting new connection: http://localhost:11311/
DEBUG [roslibrust::ros1::xmlrpc_server] New node xmlrpc connection AddrStream { inner: PollEvented { io: Some(TcpStream { addr: 127.0.1.1:39643, peer: 127.0.0.1:57142, fd: 12 }) }, remote_addr: 127.0.0.1:57142, local_addr: 127.0.1.1:39643 }
DEBUG [roslibrust::ros1::xmlrpc_server] requestTopic called by [String("/listener"), String("/chatter"), Array([Array([String("TCPROS")])])]
DEBUG [roslibrust::ros1::xmlrpc_server] Request for topic /chatter from /listener via protocols ["TCPROS"]
DEBUG [roslibrust::ros1::xmlrpc_server] Sending response for requested topic Response { status: 200, version: HTTP/1.1, headers: {}, body: Body(Full(b"<?xml version=\"1.0\" encoding=\"utf-8\"?><methodResponse><params><param><value><array><data><value><int>1</int></value><value><string>ready on pop-os:43577</string></value><value><array><data><value><string>TCPROS</string></value><value><string>pop-os</string></value><value><int>43577</int></value></data></array></value></data></array></value></param></params></methodResponse>")) }
INFO [roslibrust::ros1::publisher] Received connection from subscriber at 127.0.0.1:41932 for topic /chatter
DEBUG [roslibrust::ros1::publisher] Received subscribe request for /chatter
```