### PR TITLE
Add a submodule for managing logic around graph name validation and resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -856,9 +856,9 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
 name = "mime"
@@ -1144,9 +1144,21 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.1"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
+checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1155,9 +1167,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.1"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "reqwest"
@@ -1215,6 +1227,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "rand",
+ "regex",
  "reqwest",
  "roslibrust_codegen",
  "roslibrust_codegen_macro",

--- a/roslibrust/Cargo.toml
+++ b/roslibrust/Cargo.toml
@@ -45,6 +45,7 @@ hyper = { version = "0.14", features = [
     "server",
 ], optional = true } # Only used with native ros1
 gethostname = { version = "0.4", optional = true } # Only used with native ros1
+regex = { version = "1.9", optional = true } # Only used with native ros1
 
 [dev-dependencies]
 env_logger = "0.10"
@@ -71,6 +72,7 @@ ros1 = [
     "dep:reqwest",
     "dep:hyper",
     "dep:gethostname",
+    "dep:regex",
     "dep:serde_rosmsg",
 ]
 

--- a/roslibrust/src/ros1/mod.rs
+++ b/roslibrust/src/ros1/mod.rs
@@ -8,6 +8,8 @@ pub use master_client::*;
 mod xmlrpc_server;
 pub(crate) use xmlrpc_server::*;
 
+mod names;
+
 /// [node] module contains the central Node and NodeHandle APIs
 mod node;
 pub use node::*;

--- a/roslibrust/src/ros1/names.rs
+++ b/roslibrust/src/ros1/names.rs
@@ -1,5 +1,5 @@
 lazy_static::lazy_static! {
-    static ref GRAPH_NAME_REGEX: regex::Regex = regex::Regex::new(r"^[/~A-z][A-z0-9_/]*[A-z0-9_]$").unwrap();
+    static ref GRAPH_NAME_REGEX: regex::Regex = regex::Regex::new(r"^([/~a-zA-Z]){1}([a-zA-Z0-9_/])*([A-z0-9_])$").unwrap();
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -29,16 +29,20 @@ impl Name {
             match components.len() {
                 0..=1 => unreachable!("Node name {} must have at least one /", node_name.inner),
                 2 => Name {
-                    inner: format!("/{}/{}", components[1], self.inner),
+                    inner: format!("/{}", self.inner),
                 },
                 len => Name {
-                    inner: components[1..len - 1].into_iter().fold(
-                        String::new(),
-                        |mut name, component| {
-                            name.push('/');
-                            name.push_str(component);
-                            name
-                        },
+                    inner: format!(
+                        "{}/{}",
+                        components[1..len - 1].into_iter().fold(
+                            String::new(),
+                            |mut name, component| {
+                                name.push('/');
+                                name.push_str(component);
+                                name
+                            },
+                        ),
+                        self.inner
                     ),
                 },
             }

--- a/roslibrust/src/ros1/names.rs
+++ b/roslibrust/src/ros1/names.rs
@@ -1,0 +1,115 @@
+lazy_static::lazy_static! {
+    static ref GRAPH_NAME_REGEX: regex::Regex = regex::Regex::new(r"^[/~A-z][A-z0-9_/]*[A-z0-9_]$").unwrap();
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Name {
+    inner: String,
+}
+
+impl Name {
+    pub fn new(name: impl Into<String>) -> Option<Self> {
+        let name: String = name.into();
+        if is_valid(&name) {
+            Some(Self { inner: name })
+        } else {
+            None
+        }
+    }
+
+    pub fn resolve_to_global(&self, node_name: &Name) -> Self {
+        if self.inner.starts_with('/') {
+            self.clone()
+        } else if self.inner.starts_with('~') {
+            Name {
+                inner: format!("{}/{}", node_name.inner, &self.inner[1..]),
+            }
+        } else {
+            let components = node_name.inner.split("/").collect::<Vec<_>>();
+            match components.len() {
+                0..=1 => unreachable!("Node name {} must have at least one /", node_name.inner),
+                2 => Name {
+                    inner: format!("/{}/{}", components[1], self.inner),
+                },
+                len => Name {
+                    inner: components[1..len - 1].into_iter().fold(
+                        String::new(),
+                        |mut name, component| {
+                            name.push('/');
+                            name.push_str(component);
+                            name
+                        },
+                    ),
+                },
+            }
+        }
+    }
+}
+
+fn is_valid(name: &str) -> bool {
+    GRAPH_NAME_REGEX.is_match(name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_name_valid() {
+        assert!(is_valid("base"));
+        assert!(is_valid("relative/name"));
+        assert!(is_valid("/global/name"));
+        assert!(is_valid("~private/name"));
+
+        // These are invalid names
+        assert!(!is_valid("~"));
+        assert!(!is_valid("~~"));
+        assert!(!is_valid("_leading"));
+    }
+
+    // Examples pulled from http://wiki.ros.org/Names
+    #[test]
+    fn resolve_name() {
+        let node1 = Name::new("/node1").unwrap();
+        assert_eq!(
+            Name::new("bar").unwrap().resolve_to_global(&node1),
+            Name::new("/bar").unwrap()
+        );
+        assert_eq!(
+            Name::new("/bar").unwrap().resolve_to_global(&node1),
+            Name::new("/bar").unwrap()
+        );
+        assert_eq!(
+            Name::new("~bar").unwrap().resolve_to_global(&node1),
+            Name::new("/node1/bar").unwrap()
+        );
+
+        let node2 = Name::new("/wg/node2").unwrap();
+        assert_eq!(
+            Name::new("bar").unwrap().resolve_to_global(&node2),
+            Name::new("/wg/bar").unwrap()
+        );
+        assert_eq!(
+            Name::new("/bar").unwrap().resolve_to_global(&node2),
+            Name::new("/bar").unwrap()
+        );
+        assert_eq!(
+            Name::new("~bar").unwrap().resolve_to_global(&node2),
+            Name::new("/wg/node2/bar").unwrap()
+        );
+
+        let node3 = Name::new("/wg/node3").unwrap();
+        assert_eq!(
+            Name::new("foo/bar").unwrap().resolve_to_global(&node3),
+            Name::new("/wg/foo/bar").unwrap()
+        );
+        assert_eq!(
+            Name::new("/foo/bar").unwrap().resolve_to_global(&node3),
+            Name::new("/foo/bar").unwrap()
+        );
+        assert_eq!(
+            Name::new("~foo/bar").unwrap().resolve_to_global(&node3),
+            Name::new("/wg/node3/foo/bar").unwrap()
+        );
+    }
+}


### PR DESCRIPTION
Add a submodule for managing logic around graph name validation and resolution.

Pulled the tests from the ROS docs: http://wiki.ros.org/Names 