### PR TITLE
Better errors from codegen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1256,6 +1256,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
+ "simple-error",
  "syn 1.0.109",
  "test-log",
  "tokio",
@@ -1473,6 +1474,12 @@ checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "simple-error"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8542b68b8800c3cda649d2c72d688b6907b30f1580043135d61669d4aad1c175"
 
 [[package]]
 name = "simple_logger"

--- a/roslibrust_codegen/Cargo.toml
+++ b/roslibrust_codegen/Cargo.toml
@@ -20,6 +20,7 @@ proc-macro2 = "1.0"
 quote = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+simple-error = "0.3"
 syn = "1.0"
 tokio = { version = "1.0", features = ["time", "signal"], optional = true}
 walkdir = "2.3"

--- a/roslibrust_codegen/src/gen.rs
+++ b/roslibrust_codegen/src/gen.rs
@@ -258,12 +258,15 @@ fn parse_ros_value(ros_type: &str, value: &str, array_info: Option<Option<usize>
                 quote! { #vec_str }
             } else {
                 // Halfass attempt to deal with ROS's string escaping / quote bullshit
+                // TODO bug here: https://github.com/Carter12s/roslibrust/issues/129
                 let value = &value.replace('\'', "\"");
+                // TODO need to return result here
                 let parsed: String = serde_json::from_str(value).unwrap_or_else(|_| panic!("Failed to parse a literal value in a message file to the corresponding rust type: {value} to String"));
                 quote! { #parsed }
             }
         }
         _ => {
+            // TODO need to return result here
             panic!("Found default for type which does not support default: {ros_type}");
         }
     }

--- a/roslibrust_codegen/src/lib.rs
+++ b/roslibrust_codegen/src/lib.rs
@@ -382,7 +382,10 @@ pub fn find_and_parse_ros_messages(
     let search_paths  = search_paths
         .into_iter()
         .map(|path| {
-                path.canonicalize().map_err(|e| Error::with(format!("Codegen was instructed to search a path that could not be canonicalized relative to {:?}: {path:?}", std::env::current_dir().unwrap()).as_str(), e))
+            path.canonicalize().map_err(
+            |e| {
+                    Error::with(format!("Codegen was instructed to search a path that could not be canonicalized relative to {:?}: {path:?}", std::env::current_dir().unwrap()).as_str(), e)
+        })
         })
         .collect::<Result<Vec<_>, Error>>()?;
     debug!(

--- a/roslibrust_codegen/src/lib.rs
+++ b/roslibrust_codegen/src/lib.rs
@@ -491,7 +491,7 @@ struct MessageMetadata {
 pub fn resolve_dependency_graph(
     messages: Vec<ParsedMessageFile>,
     services: Vec<ParsedServiceFile>,
-) -> Option<(Vec<MessageFile>, Vec<ServiceFile>)> {
+) -> Result<(Vec<MessageFile>, Vec<ServiceFile>), Error> {
     const MAX_PARSE_ITER_LIMIT: u32 = 2048;
     let mut unresolved_messages = messages
         .into_iter()

--- a/roslibrust_codegen/src/parse/msg.rs
+++ b/roslibrust_codegen/src/parse/msg.rs
@@ -61,10 +61,10 @@ pub fn parse_ros_message_file(
         let equal_after_sep = line[sep..].find('=');
         if equal_after_sep.is_some() {
             // Since we found an equal sign after a space, this must be a constant
-            constants.push(parse_constant_field(line, package))
+            constants.push(parse_constant_field(line, package)?)
         } else {
             // Is regular field
-            fields.push(parse_field(line, package, name));
+            fields.push(parse_field(line, package, name)?);
         }
     }
     Ok(ParsedMessageFile {

--- a/roslibrust_codegen/src/parse/msg.rs
+++ b/roslibrust_codegen/src/parse/msg.rs
@@ -1,5 +1,5 @@
 use crate::parse::{parse_constant_field, parse_field, strip_comments};
-use crate::{bail, Error};
+use crate::Error;
 use crate::{ConstantInfo, FieldInfo, Package, RosVersion};
 use std::path::{Path, PathBuf};
 

--- a/roslibrust_codegen/src/parse/srv.rs
+++ b/roslibrust_codegen/src/parse/srv.rs
@@ -1,6 +1,7 @@
 use crate::{
+    bail,
     parse::{parse_ros_message_file, ParsedMessageFile},
-    Package,
+    Error, Package,
 };
 use std::path::{Path, PathBuf};
 
@@ -34,7 +35,7 @@ pub fn parse_ros_service_file(
     name: &str,
     package: &Package,
     path: &Path,
-) -> ParsedServiceFile {
+) -> Result<ParsedServiceFile, Error> {
     let mut dash_line_number = None;
     for (line_num, line) in data.lines().enumerate() {
         match (line.find("---"), line.find('#')) {
@@ -58,12 +59,10 @@ pub fn parse_ros_service_file(
         acc
     };
 
-    let dash_line_number = dash_line_number.unwrap_or_else(|| {
-        panic!(
-            "Failed to find delimiter line '---' in {}/{name}",
-            &package.name
-        )
-    });
+    let dash_line_number = dash_line_number.ok_or(Error::new(format!(
+        "Failed to find delimiter line '---' in {}/{name}",
+        &package.name
+    )))?;
     let request_str = data
         .lines()
         .take(dash_line_number)
@@ -73,7 +72,7 @@ pub fn parse_ros_service_file(
         .skip(dash_line_number + 1)
         .fold(String::new(), str_accumulator);
 
-    ParsedServiceFile {
+    Ok(ParsedServiceFile {
         name: name.to_owned(),
         package: package.name.clone(),
         request_type: parse_ros_message_file(
@@ -81,14 +80,14 @@ pub fn parse_ros_service_file(
             format!("{name}Request").as_str(),
             package,
             path,
-        ),
+        )?,
         response_type: parse_ros_message_file(
             &response_str,
             format!("{name}Response").as_str(),
             package,
             path,
-        ),
+        )?,
         source: data.to_owned(),
         path: path.to_owned(),
-    }
+    })
 }

--- a/roslibrust_codegen/src/parse/srv.rs
+++ b/roslibrust_codegen/src/parse/srv.rs
@@ -1,5 +1,4 @@
 use crate::{
-    bail,
     parse::{parse_ros_message_file, ParsedMessageFile},
     Error, Package,
 };

--- a/roslibrust_codegen_macro/src/lib.rs
+++ b/roslibrust_codegen_macro/src/lib.rs
@@ -32,7 +32,13 @@ impl Parse for RosLibRustMessagePaths {
 pub fn find_and_generate_ros_messages(input_stream: TokenStream) -> TokenStream {
     let RosLibRustMessagePaths { paths } =
         parse_macro_input!(input_stream as RosLibRustMessagePaths);
-    roslibrust_codegen::find_and_generate_ros_messages(paths).into()
+    match roslibrust_codegen::find_and_generate_ros_messages(paths) {
+        Ok(t) => t.into(),
+        Err(e) => {
+            let error_msg = e.to_string();
+            quote::quote!(compile_error!(#error_msg);).into()
+        }
+    }
 }
 
 /// Does the same as find_and_generate_ros_messages, but interprets relative paths
@@ -51,7 +57,13 @@ pub fn find_and_generate_ros_messages_relative_to_manifest_dir(
         });
     }
 
-    roslibrust_codegen::find_and_generate_ros_messages(paths).into()
+    match roslibrust_codegen::find_and_generate_ros_messages(paths) {
+        Ok(t) => t.into(),
+        Err(e) => {
+            let error_msg = e.to_string();
+            quote::quote!(compile_error!(#error_msg);).into()
+        }
+    }
 }
 
 /// Similar to `find_and_generate_ros_messages`, but does not search the
@@ -62,5 +74,11 @@ pub fn find_and_generate_ros_messages_without_ros_package_path(
 ) -> TokenStream {
     let RosLibRustMessagePaths { paths } =
         parse_macro_input!(input_stream as RosLibRustMessagePaths);
-    roslibrust_codegen::find_and_generate_ros_messages_without_ros_package_path(paths).into()
+    match roslibrust_codegen::find_and_generate_ros_messages_without_ros_package_path(paths) {
+        Ok(t) => t.into(),
+        Err(e) => {
+            let error_msg = e.to_string();
+            quote::quote!( compile_error!(#error_msg); ).into()
+        }
+    }
 }

--- a/roslibrust_genmsg/src/lib.rs
+++ b/roslibrust_genmsg/src/lib.rs
@@ -87,8 +87,10 @@ impl<'a> CodeGeneratorBuilder<'a> {
     /// Performs discovery of ROS messages, services, and actions, resolves their
     /// dependency graph and builds a `CodeGenerator`.
     pub fn build(self) -> std::io::Result<CodeGenerator<'a>> {
+        // Being lazy here and not infecting other error types to far
+        // Eventually I think we should move away from io::Result here and remove both of these unwraps
         let (messages, services) =
-            roslibrust_codegen::find_and_parse_ros_messages(&self.msg_paths)?;
+            roslibrust_codegen::find_and_parse_ros_messages(&self.msg_paths).unwrap();
         let (messages, services) =
             roslibrust_codegen::resolve_dependency_graph(messages, services).unwrap();
 

--- a/roslibrust_genmsg/src/lib.rs
+++ b/roslibrust_genmsg/src/lib.rs
@@ -87,7 +87,8 @@ impl<'a> CodeGeneratorBuilder<'a> {
     /// Performs discovery of ROS messages, services, and actions, resolves their
     /// dependency graph and builds a `CodeGenerator`.
     pub fn build(self) -> std::io::Result<CodeGenerator<'a>> {
-        let (messages, services) = roslibrust_codegen::find_and_parse_ros_messages(self.msg_paths)?;
+        let (messages, services) =
+            roslibrust_codegen::find_and_parse_ros_messages(&self.msg_paths)?;
         let (messages, services) =
             roslibrust_codegen::resolve_dependency_graph(messages, services).unwrap();
 

--- a/roslibrust_test/src/main.rs
+++ b/roslibrust_test/src/main.rs
@@ -23,20 +23,22 @@ lazy_static! {
 }
 
 /// This main function is used to generate the contents of ros1.rs, ros2.rs
-fn main() {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
     let tokens = roslibrust_codegen::find_and_generate_ros_messages_without_ros_package_path(
         (*ROS_1_PATHS).clone(),
-    );
+    )?;
     let source = format_rust_source(tokens.to_string().as_str()).to_string();
-    let _ = std::fs::write(concat!(env!("CARGO_MANIFEST_DIR"), "/src/ros1.rs"), source);
+    std::fs::write(concat!(env!("CARGO_MANIFEST_DIR"), "/src/ros1.rs"), source)?;
 
-    let tokens = roslibrust_codegen::find_and_generate_ros_messages_without_ros_package_path(vec![
-        ROS_2_PATH.into(),
-        ROS_2_TEST_PATH.into(),
-    ]);
+    let tokens =
+        roslibrust_codegen::find_and_generate_ros_messages_without_ros_package_path(vec![
+            ROS_2_PATH.into(),
+            ROS_2_TEST_PATH.into(),
+        ])?;
     let source = format_rust_source(tokens.to_string().as_str()).to_string();
-    let _ = std::fs::write(concat!(env!("CARGO_MANIFEST_DIR"), "/src/ros2.rs"), source);
+    std::fs::write(concat!(env!("CARGO_MANIFEST_DIR"), "/src/ros2.rs"), source)?;
+    Ok(())
 }
 
 fn format_rust_source(source: &str) -> Cow<'_, str> {

--- a/roslibrust_test/src/main.rs
+++ b/roslibrust_test/src/main.rs
@@ -76,7 +76,7 @@ mod test {
         let tokens = roslibrust_codegen::find_and_generate_ros_messages_without_ros_package_path(
             (*ROS_1_PATHS).clone(),
         );
-        let source = format_rust_source(tokens.to_string().as_str()).to_string();
+        let source = format_rust_source(tokens.unwrap().to_string().as_str()).to_string();
         let lib_path = env!("CARGO_MANIFEST_DIR").to_string() + "/src/ros1.rs";
         let lib_contents =
             std::fs::read_to_string(lib_path).expect("Failed to load current ros1.rs contents");
@@ -96,7 +96,7 @@ mod test {
         let tokens = roslibrust_codegen::find_and_generate_ros_messages_without_ros_package_path(
             (*ROS_2_PATHS).clone(),
         );
-        let source = format_rust_source(tokens.to_string().as_str()).to_string();
+        let source = format_rust_source(tokens.unwrap().to_string().as_str()).to_string();
         let lib_path = env!("CARGO_MANIFEST_DIR").to_string() + "/src/ros2.rs";
         let lib_contents =
             std::fs::read_to_string(lib_path).expect("Failed to load current ros2.rs contents");


### PR DESCRIPTION
Closes: https://github.com/Carter12s/roslibrust/issues/126
Closes: https://github.com/Carter12s/roslibrust/issues/128

Trying to catch some common user errors and make them more clear. Investigated automated tests for these kinds of errors, but it looks like it is actually pretty annoying to setup. Looks like this will do the job, but a little much to setup right now: https://crates.io/crates/compiletest_rs

These test checks were manually performed by me while setting this up:
Manually modifying calling_services to introduce a typo on this line:
`roslibrust_codegen_macro::find_and_generate_ros_messages!("assets/ros1_common_interfacs",);`

Now produces the following compilation error when invoking `cargo run --example calling_service`
```
error: Failed to find any services or messages while generating ROS message definitions, paths searched: ["assets/ros1_common_interfacs"]
 --> roslibrust/examples/calling_service.rs:4:1
  |
4 | roslibrust_codegen_macro::find_and_generate_ros_messages!("assets/ros1_common_interfacs",);
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: this error originates in the macro `roslibrust_codegen_macro::find_and_generate_ros_messages` (in Nightly builds, run with -Z macro-backtrace for more info)
```
