### PR TITLE
Reorganize the code in node.rs into a couple separate files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,16 +25,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - The build.rs example in example_package now correctly informs cargo of filesystem dependencies
-- The `advertise_serveice` method in `rosbridge/client.rs` now accepts closures 
+- The `advertise_service` method in `rosbridge/client.rs` now accepts closures 
 
 ### Fixed
 
 ### Changed
 
- - Removed `find_and_generate_ros_messages_relative_to_manifest_dir!` this proc_macro was changing the current working directory of the compilation job resulting in a variety of strange compilation behaviors. Build.rs scripts are recommended for use cases requiring fine
- grained control of message generation.
- - The function interface for top level generation functions in `roslibrust_codegen` have been changed to include the list of dependent
-filesystem paths that should trigger re-running code generation. Note: new files added to the search paths will not be automatically detected.
+ - Removed `find_and_generate_ros_messages_relative_to_manifest_dir!` this proc_macro was changing the current working directory of the compilation job resulting in a variety of strange compilation behaviors. Build.rs scripts are recommended for use cases requiring fine grained control of message generation.
+ - The function interface for top level generation functions in `roslibrust_codegen` have been changed to include the list of dependent filesystem paths that should trigger re-running code generation. Note: new files added to the search paths will not be automatically detected.
+ - Refactor the `ros1::node` module into separate smaller pieces. This should be invisible externally (and no changes to examples were required).
 
 ## 0.8.0 - October 4th, 2023
 

--- a/roslibrust/examples/native_ros1.rs
+++ b/roslibrust/examples/native_ros1.rs
@@ -5,7 +5,7 @@
 #[cfg(feature = "ros1")]
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    use roslibrust::NodeHandle;
+    use roslibrust::ros1::NodeHandle;
 
     simple_logger::SimpleLogger::new()
         .with_level(log::LevelFilter::Debug)

--- a/roslibrust/examples/ros1_listener.rs
+++ b/roslibrust/examples/ros1_listener.rs
@@ -3,7 +3,7 @@ roslibrust_codegen_macro::find_and_generate_ros_messages!("assets/ros1_common_in
 #[cfg(feature = "ros1")]
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    use roslibrust::NodeHandle;
+    use roslibrust::ros1::NodeHandle;
 
     simple_logger::SimpleLogger::new()
         .with_level(log::LevelFilter::Debug)

--- a/roslibrust/examples/ros1_talker.rs
+++ b/roslibrust/examples/ros1_talker.rs
@@ -3,7 +3,7 @@ roslibrust_codegen_macro::find_and_generate_ros_messages!("assets/ros1_common_in
 #[cfg(feature = "ros1")]
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    use roslibrust::NodeHandle;
+    use roslibrust::ros1::NodeHandle;
 
     simple_logger::SimpleLogger::new()
         .with_level(log::LevelFilter::Debug)

--- a/roslibrust/src/ros1/master_client.rs
+++ b/roslibrust/src/ros1/master_client.rs
@@ -361,7 +361,7 @@ impl MasterClient {
 #[cfg(test)]
 mod test {
 
-    use crate::{MasterClient, RosMasterError};
+    use super::{MasterClient, RosMasterError};
 
     const TEST_NODE_ID: &str = "/native_ros1_test";
 

--- a/roslibrust/src/ros1/mod.rs
+++ b/roslibrust/src/ros1/mod.rs
@@ -4,10 +4,6 @@
 mod master_client;
 pub use master_client::*;
 
-/// [xmlrpc_server] module contains the xmlrpc server that a node must host
-mod xmlrpc_server;
-pub(crate) use xmlrpc_server::*;
-
 mod names;
 
 /// [node] module contains the central Node and NodeHandle APIs

--- a/roslibrust/src/ros1/mod.rs
+++ b/roslibrust/src/ros1/mod.rs
@@ -11,5 +11,7 @@ mod node;
 pub use node::*;
 
 mod publisher;
+pub use publisher::Publisher;
 mod subscriber;
+pub use subscriber::Subscriber;
 mod tcpros;

--- a/roslibrust/src/ros1/names.rs
+++ b/roslibrust/src/ros1/names.rs
@@ -1,3 +1,6 @@
+use crate::{RosLibRustError, RosLibRustResult};
+use std::fmt::Display;
+
 lazy_static::lazy_static! {
     static ref GRAPH_NAME_REGEX: regex::Regex = regex::Regex::new(r"^([/~a-zA-Z]){1}([a-zA-Z0-9_/])*([A-z0-9_])$").unwrap();
 }
@@ -8,12 +11,12 @@ pub struct Name {
 }
 
 impl Name {
-    pub fn new(name: impl Into<String>) -> Option<Self> {
+    pub fn new(name: impl Into<String>) -> RosLibRustResult<Self> {
         let name: String = name.into();
         if is_valid(&name) {
-            Some(Self { inner: name })
+            Ok(Self { inner: name })
         } else {
-            None
+            Err(RosLibRustError::InvalidName(name))
         }
     }
 
@@ -52,6 +55,12 @@ impl Name {
 
 fn is_valid(name: &str) -> bool {
     GRAPH_NAME_REGEX.is_match(name)
+}
+
+impl Display for Name {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.inner.fmt(f)
+    }
 }
 
 #[cfg(test)]

--- a/roslibrust/src/ros1/node/handle.rs
+++ b/roslibrust/src/ros1/node/handle.rs
@@ -1,0 +1,60 @@
+use super::actor::{Node, NodeServerHandle};
+use crate::ros1::{publisher::Publisher, subscriber::Subscriber};
+
+/// Represents a handle to an underlying [Node]. NodeHandle's can be freely cloned, moved, copied, etc.
+/// This class provides the user facing API for interacting with ROS.
+#[derive(Clone)]
+pub struct NodeHandle {
+    inner: NodeServerHandle,
+}
+
+impl NodeHandle {
+    // TODO builder, result, better error type
+    /// Creates a new node connect and returns a handle to it
+    /// It is idiomatic to call this once per process and treat the created node as singleton.
+    /// The returned handle can be freely clone'd to create additional handles without creating additional connections.
+    pub async fn new(
+        master_uri: &str,
+        name: &str,
+    ) -> Result<NodeHandle, Box<dyn std::error::Error + Send + Sync>> {
+        // Follow ROS rules and determine our IP and hostname
+        let (addr, hostname) = super::determine_addr().await?;
+
+        let node = Node::new(master_uri, &hostname, name, addr).await?;
+        let nh = NodeHandle { inner: node };
+
+        Ok(nh)
+    }
+
+    pub fn is_ok(&self) -> bool {
+        !self.inner.node_server_sender.is_closed()
+    }
+
+    pub async fn get_client_uri(&self) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+        self.inner.get_client_uri().await
+    }
+
+    pub async fn advertise<T: roslibrust_codegen::RosMessageType>(
+        &self,
+        topic_name: &str,
+        queue_size: usize,
+    ) -> Result<Publisher<T>, Box<dyn std::error::Error + Send + Sync>> {
+        let sender = self
+            .inner
+            .register_publisher::<T>(topic_name, T::ROS_TYPE_NAME, queue_size)
+            .await?;
+        Ok(Publisher::new(topic_name, sender))
+    }
+
+    pub async fn subscribe<T: roslibrust_codegen::RosMessageType>(
+        &self,
+        topic_name: &str,
+        queue_size: usize,
+    ) -> Result<Subscriber<T>, Box<dyn std::error::Error + Send + Sync>> {
+        let receiver = self
+            .inner
+            .register_subscriber::<T>(topic_name, queue_size)
+            .await?;
+        Ok(Subscriber::new(receiver))
+    }
+}

--- a/roslibrust/src/ros1/node/handle.rs
+++ b/roslibrust/src/ros1/node/handle.rs
@@ -41,7 +41,7 @@ impl NodeHandle {
     ) -> Result<Publisher<T>, Box<dyn std::error::Error + Send + Sync>> {
         let sender = self
             .inner
-            .register_publisher::<T>(topic_name, T::ROS_TYPE_NAME, queue_size)
+            .register_publisher::<T>(topic_name, queue_size)
             .await?;
         Ok(Publisher::new(topic_name, sender))
     }

--- a/roslibrust/src/ros1/node/mod.rs
+++ b/roslibrust/src/ros1/node/mod.rs
@@ -1,0 +1,70 @@
+//! This module contains the top level Node and NodeHandle classes.
+//! These wrap the lower level management of a ROS Node connection into a higher level and thread safe API.
+
+use crate::RosMasterError;
+use std::net::{IpAddr, Ipv4Addr};
+
+mod actor;
+mod handle;
+mod xmlrpc;
+use actor::*;
+pub use handle::NodeHandle;
+use xmlrpc::*;
+
+#[derive(Debug)]
+pub struct ProtocolParams {
+    pub hostname: String,
+    pub protocol: String,
+    pub port: u16,
+}
+
+// TODO at the end of the day I'd like to offer a builder pattern for configuration that allow manual setting of this or "ros idiomatic" behavior - Carter
+/// Following ROS's idiomatic address rules uses ROS_HOSTNAME and ROS_IP to determine the address that server should be hosted at.
+/// Returns both the resolved IpAddress of the host (used for actually opening the socket), and the String "hostname" which should
+/// be used in the URI.
+async fn determine_addr() -> Result<(Ipv4Addr, String), RosMasterError> {
+    // If ROS_IP is set that trumps anything else
+    if let Ok(ip_str) = std::env::var("ROS_IP") {
+        let ip = ip_str.parse().map_err(|e| {
+            RosMasterError::HostIpResolutionFailure(format!(
+                "ROS_IP environment variable did not parse to a valid IpAddr::V4: {e:?}"
+            ))
+        })?;
+        return Ok((ip, ip_str));
+    }
+    // If ROS_HOSTNAME is set that is next highest precedent
+    if let Ok(name) = std::env::var("ROS_HOSTNAME") {
+        let ip = hostname_to_ipv4(&name).await?;
+        return Ok((ip, name));
+    }
+    // If neither env var is set, use the computers "hostname"
+    let name = gethostname::gethostname();
+    let name = name.into_string().map_err(|e| {
+            RosMasterError::HostIpResolutionFailure(format!("This host's hostname is a string that cannot be validly converted into a Rust type, and therefore we cannot convert it into an IpAddrv4: {e:?}"))
+        })?;
+    let ip = hostname_to_ipv4(&name).await?;
+    return Ok((ip, name));
+}
+
+/// Given a the name of a host use's std::net::ToSocketAddrs to perform a DNS lookup and return the resulting IP address.
+/// This function is intended to be used to determine the correct IP host the socket for the xmlrpc server on.
+async fn hostname_to_ipv4(name: &str) -> Result<Ipv4Addr, RosMasterError> {
+    let name_with_port = &format!("{name}:0");
+    let mut i = tokio::net::lookup_host(name_with_port).await.map_err(|e| {
+        RosMasterError::HostIpResolutionFailure(format!(
+            "Failure while attempting to lookup ROS_HOSTNAME: {e:?}"
+        ))
+    })?;
+    if let Some(addr) = i.next() {
+        match addr.ip() {
+                IpAddr::V4(ip) => Ok(ip),
+                IpAddr::V6(ip) => {
+                    Err(RosMasterError::HostIpResolutionFailure(format!("ROS_HOSTNAME resolved to an IPv6 address which is not support by ROS/roslibrust: {ip:?}")))
+                }
+            }
+    } else {
+        Err(RosMasterError::HostIpResolutionFailure(format!(
+            "ROS_HOSTNAME did not resolve any address: {name:?}"
+        )))
+    }
+}

--- a/roslibrust/src/ros1/node/mod.rs
+++ b/roslibrust/src/ros1/node/mod.rs
@@ -1,7 +1,7 @@
 //! This module contains the top level Node and NodeHandle classes.
 //! These wrap the lower level management of a ROS Node connection into a higher level and thread safe API.
 
-use crate::RosMasterError;
+use super::RosMasterError;
 use std::net::{IpAddr, Ipv4Addr};
 
 mod actor;

--- a/roslibrust/src/ros1/node/xmlrpc.rs
+++ b/roslibrust/src/ros1/node/xmlrpc.rs
@@ -1,4 +1,4 @@
-use super::node::NodeServerHandle;
+use super::NodeServerHandle;
 use abort_on_drop::ChildTask;
 use hyper::{Body, Response, StatusCode};
 use log::*;

--- a/roslibrust/src/ros1/publisher.rs
+++ b/roslibrust/src/ros1/publisher.rs
@@ -1,6 +1,4 @@
-use crate::RosLibRustError;
-
-use super::tcpros::ConnectionHeader;
+use crate::{ros1::tcpros::ConnectionHeader, RosLibRustError};
 use abort_on_drop::ChildTask;
 use roslibrust_codegen::RosMessageType;
 use std::{

--- a/roslibrust/src/ros1/subscriber.rs
+++ b/roslibrust/src/ros1/subscriber.rs
@@ -1,4 +1,4 @@
-use super::tcpros::ConnectionHeader;
+use crate::ros1::tcpros::ConnectionHeader;
 use abort_on_drop::ChildTask;
 use roslibrust_codegen::RosMessageType;
 use std::{marker::PhantomData, sync::Arc};

--- a/roslibrust/src/rosbridge/mod.rs
+++ b/roslibrust/src/rosbridge/mod.rs
@@ -30,46 +30,13 @@ mod topic_provider;
 mod comm;
 
 use futures_util::stream::{SplitSink, SplitStream};
-use log::*;
 use std::collections::HashMap;
 use tokio::net::TcpStream;
 use tokio_tungstenite::*;
 use tungstenite::Message;
 
-/// For now starting with a central error type, may break this up more in future
-#[derive(thiserror::Error, Debug)]
-pub enum RosLibRustError {
-    #[error("Not currently connected to ros master / bridge")]
-    Disconnected,
-    // TODO we probably want to eliminate tungstenite from this and hide our
-    // underlying websocket implementation from the API
-    // currently we "technically" break the API when we change tungstenite verisons
-    #[error("Websocket communication error: {0}")]
-    CommFailure(tokio_tungstenite::tungstenite::Error),
-    #[error("Operation timed out: {0}")]
-    Timeout(#[from] tokio::time::error::Elapsed),
-    #[error("Failed to parse message from JSON: {0}")]
-    InvalidMessage(#[from] serde_json::Error),
-    #[error("Rosbridge server reported an error: {0}")]
-    ServerError(String),
-    // Generic catch-all error type for not-yet-handled errors
-    // TODO ultimately this type will be removed from API of library
-    #[error(transparent)]
-    Unexpected(#[from] anyhow::Error),
-}
-
-/// Provides an implementation tranlating the underlying websocket error into our error type
-impl From<tokio_tungstenite::tungstenite::Error> for RosLibRustError {
-    fn from(e: tokio_tungstenite::tungstenite::Error) -> Self {
-        // TODO we probably want to expand this type and do some matching here
-        RosLibRustError::CommFailure(e)
-    }
-}
-
-/// Generic result type used as standard throughout library.
-/// Note: many functions which currently return this will be updated to provide specific error
-/// types in the future instead of the generic error here.
-pub type RosLibRustResult<T> = Result<T, RosLibRustError>;
+// Doing this to maintain backwards compatibilities like `use roslibrust::rosbridge::RosLibRustError`
+pub use super::{RosLibRustError, RosLibRustResult};
 
 /// Used for type erasure of message type so that we can store arbitrary handles
 type Callback = Box<dyn Fn(&str) + Send + Sync>;

--- a/roslibrust/tests/ros1_xmlrpc.rs
+++ b/roslibrust/tests/ros1_xmlrpc.rs
@@ -1,5 +1,6 @@
 #[cfg(all(feature = "ros1", feature = "ros1_test"))]
 mod tests {
+    use roslibrust::ros1::NodeHandle;
     use roslibrust_codegen::RosMessageType;
     use serde::de::DeserializeOwned;
     use serde_xmlrpc::Value;
@@ -27,8 +28,7 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn verify_get_master_uri() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let node =
-            roslibrust::NodeHandle::new("http://localhost:11311", "verify_get_master_uri").await?;
+        let node = NodeHandle::new("http://localhost:11311", "verify_get_master_uri").await?;
         log::info!("Got new handle");
 
         let node_uri = node.get_client_uri().await?;
@@ -48,8 +48,7 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn verify_get_publications() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let node = roslibrust::NodeHandle::new("http://localhost:11311", "verify_get_publications")
-            .await?;
+        let node = NodeHandle::new("http://localhost:11311", "verify_get_publications").await?;
         log::info!("Got new handle");
 
         let node_uri = node.get_client_uri().await?;
@@ -86,7 +85,7 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn verify_shutdown() {
-        let node = roslibrust::NodeHandle::new("http://localhost:11311", "verify_shutdown")
+        let node = NodeHandle::new("http://localhost:11311", "verify_shutdown")
             .await
             .unwrap();
         log::info!("Got handle");
@@ -110,7 +109,7 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn verify_request_topic() {
-        let node = roslibrust::NodeHandle::new("http://localhost:11311", "verify_request_topic")
+        let node = NodeHandle::new("http://localhost:11311", "verify_request_topic")
             .await
             .unwrap();
         log::info!("Got handle");


### PR DESCRIPTION
## Description
Reorganize the code in node.rs into a couple separate files with different areas of concern to manage growing number of node actor methods.

As I was starting in on implementation of native Service Clients I was finding the code here growing in difficulty to navigate `node.rs` so I split it:
* `mod.rs` is for helpers and utilities
* `actor.rs` is where most of the node administration lives for the `NodeServer` actor
* `handle.rs` is for the struct that user code uses as a handle
* `xmlrpc.rs` has the former `xmlrpc_server.rs` module since a lot of that code was tied to code in `node.rs` which became clear as I was fixing `use` statements.

## Fixes
N/A

## Checklist
- [x] Update CHANGELOG.md

