### PR TITLE
Flexible public codegen APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - The build.rs example in example_package now correctly informs cargo of filesystem dependencies
-- The `advertise_serveice` method in `rosbridge/client.rs` now accepts closures 
+- The `advertise_serveice` method in `rosbridge/client.rs` now accepts closures
+- Expose additional methods useful for custom cases not using package manifests or standard ROS2 setups
 
 ### Fixed
 

--- a/roslibrust_codegen/src/utils.rs
+++ b/roslibrust_codegen/src/utils.rs
@@ -63,7 +63,7 @@ pub fn crawl<P: AsRef<Path>>(search_paths: &[P]) -> Vec<Package> {
     packages
 }
 
-fn packages_from_path(mut path: PathBuf, depth: u16) -> io::Result<Vec<Package>> {
+pub fn packages_from_path(mut path: PathBuf, depth: u16) -> io::Result<Vec<Package>> {
     let mut found_packages = vec![];
 
     if depth == 0 {


### PR DESCRIPTION
## Description
Make additional public APIs available. Use case is when consuming interface libraries using an external non-ROS build-system. `package.xml` is not available, so I need to provide the package paths manually.

## Checklist
- [x] Update CHANGELOG.md

