### PR TITLE
Support for Fixed Sized Arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,14 +25,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - The build.rs example in example_package now correctly informs cargo of filesystem dependencies
-- The `advertise_serveice` method in `rosbridge/client.rs` now accepts closures 
+- The `advertise_service` method in `rosbridge/client.rs` now accepts closures 
 
 ### Fixed
+
+- Messages containing fixed sized arrays now successfully serialize and deserialize when using ROS1 native communication
 
 ### Changed
 
  - The function interface for top level generation functions in `roslibrust_codegen` have been changed to include the list of dependent
 filesystem paths that should trigger re-running code generation. Note: new files added to the search paths will not be automatically detected.
+- [Breaking Change] Codegen now generates fixed sized arrays as arrays [T; N] instead of Vec<T>
 
 ## 0.8.0 - October 4th, 2023
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1249,6 +1249,7 @@ dependencies = [
  "roslibrust_codegen",
  "roslibrust_codegen_macro",
  "serde",
+ "serde-big-array",
  "serde_json",
  "serde_rosmsg",
  "serde_xmlrpc",
@@ -1317,6 +1318,7 @@ dependencies = [
  "roslibrust",
  "roslibrust_codegen",
  "serde",
+ "serde-big-array",
  "serde_json",
  "smart-default 0.6.0",
 ]
@@ -1401,6 +1403,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-big-array"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/roslibrust/Cargo.toml
+++ b/roslibrust/Cargo.toml
@@ -45,6 +45,8 @@ hyper = { version = "0.14", features = [
 ], optional = true } # Only used with native ros1
 gethostname = { version = "0.4", optional = true } # Only used with native ros1
 regex = { version = "1.9", optional = true } # Only used with native ros1
+# TODO I think we should move rosapi into its own crate...
+serde-big-array = { version = "0.5", optional = true } # Only used with rosapi
 
 [dev-dependencies]
 env_logger = "0.10"
@@ -57,7 +59,7 @@ default = []
 # Note: all does not include running_bridge as that is only intended for CI
 all = []
 # Provides a rosapi rust interface
-rosapi = []
+rosapi = ["serde-big-array"]
 # Intended for use with tests, includes tests that rely on a locally running rosbridge
 running_bridge = []
 # For use with integration tests, indicating we are testing integration with a ros1 bridge

--- a/roslibrust/Cargo.toml
+++ b/roslibrust/Cargo.toml
@@ -50,6 +50,7 @@ regex = { version = "1.9", optional = true } # Only used with native ros1
 env_logger = "0.10"
 test-log = "0.2"
 simple_logger = "2.1.0"
+serde-big-array = "0.5"
 
 [features]
 default = []

--- a/roslibrust_codegen/src/gen.rs
+++ b/roslibrust_codegen/src/gen.rs
@@ -173,16 +173,15 @@ fn generate_field_definition(
             quote! {}
         }
     };
-    let serde_line = if let Some(Some(fixed_array_length)) = field.field_type.array_info {
-        if fixed_array_length > 32 {
+    // This is the largest size of fixed sized array for which macros automatically implement traits
+    // Until serde supports const generics we need to use serde_big_array for fixed size arrays
+    // Larger than 32.
+    const MAX_FIXED_ARRAY_LEN: usize = 32;
+    let serde_line = match field.field_type.array_info {
+        Some(Some(fixed_array_len)) if fixed_array_len > MAX_FIXED_ARRAY_LEN => {
             quote! { #[serde(with = "::serde_big_array::BigArray")] }
-        } else {
-            // Nothing
-            quote! {}
         }
-    } else {
-        // Nothing
-        quote! {}
+        _ => quote! {},
     };
     Ok(quote! {
         #default_line

--- a/roslibrust_codegen/src/gen.rs
+++ b/roslibrust_codegen/src/gen.rs
@@ -128,7 +128,8 @@ fn generate_field_definition(
             .to_owned(),
     };
     let rust_field_type = match field.field_type.array_info {
-        Some(_) => format!("::std::vec::Vec<{rust_field_type}>"),
+        Some(None) => format!("::std::vec::Vec<{rust_field_type}>"),
+        Some(Some(fixed_length)) => format!("[{rust_field_type}; {fixed_length}]"),
         None => rust_field_type,
     };
     let rust_field_type = TokenStream::from_str(rust_field_type.as_str()).expect(

--- a/roslibrust_codegen/src/gen.rs
+++ b/roslibrust_codegen/src/gen.rs
@@ -161,7 +161,9 @@ fn generate_field_definition(
         // so we have to manually provide a default if one isn't provided for arrays that large
         if let Some(Some(fixed_array_length)) = field.field_type.array_info {
             if fixed_array_length > 32 {
-                // Okay so this is broken cause 0 isn't always a valid value... so what is?
+                // Doing some evil indirection here with the _code directive and Deafult::default()
+                // to generate the default value for a single member of the array type, and then
+                // broadcasting that with an array constant. I can't believe this works...
                 let default_str = format!("[Default::default(); {fixed_array_length}]");
                 quote! { #[default(_code = #default_str)]}
             } else {

--- a/roslibrust_codegen/src/lib.rs
+++ b/roslibrust_codegen/src/lib.rs
@@ -631,7 +631,7 @@ fn parse_ros_files(
 
 #[cfg(test)]
 mod test {
-    use crate::{find_and_generate_ros_messages, FieldInfo};
+    use crate::find_and_generate_ros_messages;
 
     /// Confirms we don't panic on ros1 parsing
     #[test_log::test]

--- a/roslibrust_codegen/src/lib.rs
+++ b/roslibrust_codegen/src/lib.rs
@@ -631,7 +631,7 @@ fn parse_ros_files(
 
 #[cfg(test)]
 mod test {
-    use crate::find_and_generate_ros_messages;
+    use crate::{find_and_generate_ros_messages, FieldInfo};
 
     /// Confirms we don't panic on ros1 parsing
     #[test_log::test]

--- a/roslibrust_codegen/src/parse/mod.rs
+++ b/roslibrust_codegen/src/parse/mod.rs
@@ -216,3 +216,24 @@ fn parse_type(type_str: &str, pkg: &Package) -> Result<FieldType, Error> {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        parse::parse_type,
+        utils::{Package, RosVersion},
+    };
+
+    // Simple test to just confirm fixed size logic is working correctly on the parse side
+    #[test_log::test]
+    fn parse_type_handles_fixed_size_correctly() {
+        let line = "int32[9]";
+        let pkg = Package {
+            name: "test_pkg".to_string(),
+            path: "./not_a_path".into(),
+            version: Some(RosVersion::ROS1),
+        };
+        let parsed = parse_type(line, &pkg).unwrap();
+        assert_eq!(parsed.array_info, Some(Some(9)));
+    }
+}

--- a/roslibrust_test/Cargo.toml
+++ b/roslibrust_test/Cargo.toml
@@ -12,6 +12,7 @@ lazy_static = "1.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 smart-default = "0.6"
+serde-big-array = "0.5"
 
 [dev-dependencies]
 diffy = "0.3.0"

--- a/roslibrust_test/src/ros1.rs
+++ b/roslibrust_test/src/ros1.rs
@@ -306,7 +306,7 @@ pub mod geometry_msgs {
     )]
     pub struct AccelWithCovariance {
         pub r#accel: self::Accel,
-        pub r#covariance: ::std::vec::Vec<f64>,
+        pub r#covariance: [f64; 36],
     }
     impl ::roslibrust_codegen::RosMessageType for AccelWithCovariance {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/AccelWithCovariance";
@@ -549,7 +549,7 @@ pub mod geometry_msgs {
     )]
     pub struct PoseWithCovariance {
         pub r#pose: self::Pose,
-        pub r#covariance: ::std::vec::Vec<f64>,
+        pub r#covariance: [f64; 36],
     }
     impl ::roslibrust_codegen::RosMessageType for PoseWithCovariance {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/PoseWithCovariance";
@@ -697,7 +697,7 @@ pub mod geometry_msgs {
     )]
     pub struct TwistWithCovariance {
         pub r#twist: self::Twist,
-        pub r#covariance: ::std::vec::Vec<f64>,
+        pub r#covariance: [f64; 36],
     }
     impl ::roslibrust_codegen::RosMessageType for TwistWithCovariance {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/TwistWithCovariance";
@@ -2443,9 +2443,9 @@ pub mod sensor_msgs {
         pub r#width: u32,
         pub r#distortion_model: ::std::string::String,
         pub r#D: ::std::vec::Vec<f64>,
-        pub r#K: ::std::vec::Vec<f64>,
-        pub r#R: ::std::vec::Vec<f64>,
-        pub r#P: ::std::vec::Vec<f64>,
+        pub r#K: [f64; 9],
+        pub r#R: [f64; 9],
+        pub r#P: [f64; 12],
         pub r#binning_x: u32,
         pub r#binning_y: u32,
         pub r#roi: self::RegionOfInterest,
@@ -2565,11 +2565,11 @@ pub mod sensor_msgs {
     pub struct Imu {
         pub r#header: std_msgs::Header,
         pub r#orientation: geometry_msgs::Quaternion,
-        pub r#orientation_covariance: ::std::vec::Vec<f64>,
+        pub r#orientation_covariance: [f64; 9],
         pub r#angular_velocity: geometry_msgs::Vector3,
-        pub r#angular_velocity_covariance: ::std::vec::Vec<f64>,
+        pub r#angular_velocity_covariance: [f64; 9],
         pub r#linear_acceleration: geometry_msgs::Vector3,
-        pub r#linear_acceleration_covariance: ::std::vec::Vec<f64>,
+        pub r#linear_acceleration_covariance: [f64; 9],
     }
     impl ::roslibrust_codegen::RosMessageType for Imu {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/Imu";
@@ -2713,7 +2713,7 @@ pub mod sensor_msgs {
     pub struct MagneticField {
         pub r#header: std_msgs::Header,
         pub r#magnetic_field: geometry_msgs::Vector3,
-        pub r#magnetic_field_covariance: ::std::vec::Vec<f64>,
+        pub r#magnetic_field_covariance: [f64; 9],
     }
     impl ::roslibrust_codegen::RosMessageType for MagneticField {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/MagneticField";
@@ -2782,7 +2782,7 @@ pub mod sensor_msgs {
         pub r#latitude: f64,
         pub r#longitude: f64,
         pub r#altitude: f64,
-        pub r#position_covariance: ::std::vec::Vec<f64>,
+        pub r#position_covariance: [f64; 9],
         pub r#position_covariance_type: u8,
     }
     impl ::roslibrust_codegen::RosMessageType for NavSatFix {
@@ -3088,7 +3088,7 @@ pub mod shape_msgs {
         PartialEq,
     )]
     pub struct MeshTriangle {
-        pub r#vertex_indices: ::std::vec::Vec<u32>,
+        pub r#vertex_indices: [u32; 3],
     }
     impl ::roslibrust_codegen::RosMessageType for MeshTriangle {
         const ROS_TYPE_NAME: &'static str = "shape_msgs/MeshTriangle";
@@ -3106,7 +3106,7 @@ pub mod shape_msgs {
         PartialEq,
     )]
     pub struct Plane {
-        pub r#coef: ::std::vec::Vec<f64>,
+        pub r#coef: [f64; 4],
     }
     impl ::roslibrust_codegen::RosMessageType for Plane {
         const ROS_TYPE_NAME: &'static str = "shape_msgs/Plane";

--- a/roslibrust_test/src/ros1.rs
+++ b/roslibrust_test/src/ros1.rs
@@ -306,6 +306,8 @@ pub mod geometry_msgs {
     )]
     pub struct AccelWithCovariance {
         pub r#accel: self::Accel,
+        #[default(_code = "[Default::default(); 36]")]
+        #[serde(with = "::serde_big_array::BigArray")]
         pub r#covariance: [f64; 36],
     }
     impl ::roslibrust_codegen::RosMessageType for AccelWithCovariance {
@@ -549,6 +551,8 @@ pub mod geometry_msgs {
     )]
     pub struct PoseWithCovariance {
         pub r#pose: self::Pose,
+        #[default(_code = "[Default::default(); 36]")]
+        #[serde(with = "::serde_big_array::BigArray")]
         pub r#covariance: [f64; 36],
     }
     impl ::roslibrust_codegen::RosMessageType for PoseWithCovariance {
@@ -697,6 +701,8 @@ pub mod geometry_msgs {
     )]
     pub struct TwistWithCovariance {
         pub r#twist: self::Twist,
+        #[default(_code = "[Default::default(); 36]")]
+        #[serde(with = "::serde_big_array::BigArray")]
         pub r#covariance: [f64; 36],
     }
     impl ::roslibrust_codegen::RosMessageType for TwistWithCovariance {

--- a/roslibrust_test/src/ros2.rs
+++ b/roslibrust_test/src/ros2.rs
@@ -299,7 +299,7 @@ pub mod geometry_msgs {
     )]
     pub struct AccelWithCovariance {
         pub r#accel: self::Accel,
-        pub r#covariance: ::std::vec::Vec<f64>,
+        pub r#covariance: [f64; 36],
     }
     impl ::roslibrust_codegen::RosMessageType for AccelWithCovariance {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/AccelWithCovariance";
@@ -541,7 +541,7 @@ pub mod geometry_msgs {
     )]
     pub struct PoseWithCovariance {
         pub r#pose: self::Pose,
-        pub r#covariance: ::std::vec::Vec<f64>,
+        pub r#covariance: [f64; 36],
     }
     impl ::roslibrust_codegen::RosMessageType for PoseWithCovariance {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/PoseWithCovariance";
@@ -692,7 +692,7 @@ pub mod geometry_msgs {
     )]
     pub struct TwistWithCovariance {
         pub r#twist: self::Twist,
-        pub r#covariance: ::std::vec::Vec<f64>,
+        pub r#covariance: [f64; 36],
     }
     impl ::roslibrust_codegen::RosMessageType for TwistWithCovariance {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/TwistWithCovariance";
@@ -1162,9 +1162,9 @@ pub mod sensor_msgs {
         pub r#width: u32,
         pub r#distortion_model: ::std::string::String,
         pub r#d: ::std::vec::Vec<f64>,
-        pub r#k: ::std::vec::Vec<f64>,
-        pub r#r: ::std::vec::Vec<f64>,
-        pub r#p: ::std::vec::Vec<f64>,
+        pub r#k: [f64; 9],
+        pub r#r: [f64; 9],
+        pub r#p: [f64; 12],
         pub r#binning_x: u32,
         pub r#binning_y: u32,
         pub r#roi: self::RegionOfInterest,
@@ -1284,11 +1284,11 @@ pub mod sensor_msgs {
     pub struct Imu {
         pub r#header: std_msgs::Header,
         pub r#orientation: geometry_msgs::Quaternion,
-        pub r#orientation_covariance: ::std::vec::Vec<f64>,
+        pub r#orientation_covariance: [f64; 9],
         pub r#angular_velocity: geometry_msgs::Vector3,
-        pub r#angular_velocity_covariance: ::std::vec::Vec<f64>,
+        pub r#angular_velocity_covariance: [f64; 9],
         pub r#linear_acceleration: geometry_msgs::Vector3,
-        pub r#linear_acceleration_covariance: ::std::vec::Vec<f64>,
+        pub r#linear_acceleration_covariance: [f64; 9],
     }
     impl ::roslibrust_codegen::RosMessageType for Imu {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/Imu";
@@ -1432,7 +1432,7 @@ pub mod sensor_msgs {
     pub struct MagneticField {
         pub r#header: std_msgs::Header,
         pub r#magnetic_field: geometry_msgs::Vector3,
-        pub r#magnetic_field_covariance: ::std::vec::Vec<f64>,
+        pub r#magnetic_field_covariance: [f64; 9],
     }
     impl ::roslibrust_codegen::RosMessageType for MagneticField {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/MagneticField";
@@ -1501,7 +1501,7 @@ pub mod sensor_msgs {
         pub r#latitude: f64,
         pub r#longitude: f64,
         pub r#altitude: f64,
-        pub r#position_covariance: ::std::vec::Vec<f64>,
+        pub r#position_covariance: [f64; 9],
         pub r#position_covariance_type: u8,
     }
     impl ::roslibrust_codegen::RosMessageType for NavSatFix {
@@ -1805,7 +1805,7 @@ pub mod shape_msgs {
         PartialEq,
     )]
     pub struct MeshTriangle {
-        pub r#vertex_indices: ::std::vec::Vec<u32>,
+        pub r#vertex_indices: [u32; 3],
     }
     impl ::roslibrust_codegen::RosMessageType for MeshTriangle {
         const ROS_TYPE_NAME: &'static str = "shape_msgs/MeshTriangle";
@@ -1823,7 +1823,7 @@ pub mod shape_msgs {
         PartialEq,
     )]
     pub struct Plane {
-        pub r#coef: ::std::vec::Vec<f64>,
+        pub r#coef: [f64; 4],
     }
     impl ::roslibrust_codegen::RosMessageType for Plane {
         const ROS_TYPE_NAME: &'static str = "shape_msgs/Plane";
@@ -1841,7 +1841,7 @@ pub mod shape_msgs {
     )]
     pub struct SolidPrimitive {
         pub r#type: u8,
-        pub r#dimensions: ::std::vec::Vec<f64>,
+        pub r#dimensions: [f64; 0],
         pub r#polygon: geometry_msgs::Polygon,
     }
     impl ::roslibrust_codegen::RosMessageType for SolidPrimitive {

--- a/roslibrust_test/src/ros2.rs
+++ b/roslibrust_test/src/ros2.rs
@@ -299,6 +299,8 @@ pub mod geometry_msgs {
     )]
     pub struct AccelWithCovariance {
         pub r#accel: self::Accel,
+        #[default(_code = "[Default::default(); 36]")]
+        #[serde(with = "::serde_big_array::BigArray")]
         pub r#covariance: [f64; 36],
     }
     impl ::roslibrust_codegen::RosMessageType for AccelWithCovariance {
@@ -541,6 +543,8 @@ pub mod geometry_msgs {
     )]
     pub struct PoseWithCovariance {
         pub r#pose: self::Pose,
+        #[default(_code = "[Default::default(); 36]")]
+        #[serde(with = "::serde_big_array::BigArray")]
         pub r#covariance: [f64; 36],
     }
     impl ::roslibrust_codegen::RosMessageType for PoseWithCovariance {
@@ -692,6 +696,8 @@ pub mod geometry_msgs {
     )]
     pub struct TwistWithCovariance {
         pub r#twist: self::Twist,
+        #[default(_code = "[Default::default(); 36]")]
+        #[serde(with = "::serde_big_array::BigArray")]
         pub r#covariance: [f64; 36],
     }
     impl ::roslibrust_codegen::RosMessageType for TwistWithCovariance {

--- a/roslibrust_test/tests/ros1_codegen_tests.rs
+++ b/roslibrust_test/tests/ros1_codegen_tests.rs
@@ -25,3 +25,16 @@ fn test_md5sum_generation() {
         "060021388200f6f0f447d0fcd9c64743"
     );
 }
+
+#[test]
+fn fixed_sized_arrays() {
+    // Prove the default works, compiler failure here is the test
+    let x: sensor_msgs::NavSatFix = Default::default();
+    // Prove the types here match, compiler failure here is the test
+    let _y: [f64; 9] = x.position_covariance;
+    // NavSatFix is the easy case because it is <32 items long
+
+    // Harder case that deals with arrays >32
+    let x: geometry_msgs::TwistWithCovariance = Default::default();
+    let _y: [f64; 36] = x.covariance;
+}

--- a/roslibrust_test/tests/ros2_codegen_tests.rs
+++ b/roslibrust_test/tests/ros2_codegen_tests.rs
@@ -10,3 +10,16 @@ fn test_defaults() {
     assert_eq!(x.s_vec, vec!["hello", "world"]);
     assert_eq!(x.f_samples, vec![-200.0, -1.0, 0.0]);
 }
+
+#[test]
+fn fixed_sized_arrays() {
+    // Prove the default works, compiler failure here is the test
+    let x: sensor_msgs::NavSatFix = Default::default();
+    // Prove the types here match, compiler failure here is the test
+    let _y: [f64; 9] = x.position_covariance;
+    // NavSatFix is the easy case because it is <32 items long
+
+    // Harder case that deals with arrays >32
+    let x: geometry_msgs::TwistWithCovariance = Default::default();
+    let _y: [f64; 36] = x.covariance;
+}


### PR DESCRIPTION
## Description
ROS1 serialization with serde_rosmsg requires that fixed sized arrays be represented not as Vec<_> but as [_; N]. The two are sent over the wire differently. Most of the support for this was already plumbed through, so this just closed the loop at the end, but is hitting the "const generic" barrier.

## Fixes
Closes: #148 

## Checklist
- [x] Update CHANGELOG.md

