### PR TITLE
Debugging rostopic hz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - The reconnection logic for rosbridge clients was fundamentally broken and failing to reconnect. This has been fixed.
+- Generic subscriptions coming from rospy that specified "*" as the md5sum were not properly handled. This has been fixed.
 
 ### Changed
 

--- a/roslibrust/src/ros1/publisher.rs
+++ b/roslibrust/src/ros1/publisher.rs
@@ -88,27 +88,35 @@ impl Publication {
                         if let Ok(connection_header) =
                             ConnectionHeader::from_bytes(&connection_header[..bytes])
                         {
-                            if connection_header.md5sum == responding_conn_header.md5sum {
-                                log::debug!(
-                                    "Received subscribe request for {}",
-                                    connection_header.topic
+                            log::debug!(
+                                "Received subscribe request for {} with md5sum {}",
+                                connection_header.topic,
+                                connection_header.md5sum
+                            );
+                            if connection_header.md5sum != responding_conn_header.md5sum {
+                                log::warn!(
+                                    "Got subscribe request for {}, but md5sums do not match. Expected {}, received {}",
+                                    topic_name,
+                                    connection_header.md5sum,
+                                    responding_conn_header.md5sum
                                 );
-                                // Write our own connection header in response
-                                let response_header_bytes = responding_conn_header
-                                    .to_bytes(false)
-                                    .expect("Couldn't serialize connection header");
-                                stream
-                                    .write(&response_header_bytes[..])
-                                    .await
-                                    .expect("Unable to respond on tcpstream");
-                                let mut wlock = subscriber_streams.write().await;
-                                wlock.push(stream);
-                                log::debug!(
-                                    "Added stream for topic {} to subscriber {}",
-                                    connection_header.topic,
-                                    peer_addr
-                                );
+                                continue;
                             }
+                            // Write our own connection header in response
+                            let response_header_bytes = responding_conn_header
+                                .to_bytes(false)
+                                .expect("Couldn't serialize connection header");
+                            stream
+                                .write(&response_header_bytes[..])
+                                .await
+                                .expect("Unable to respond on tcpstream");
+                            let mut wlock = subscriber_streams.write().await;
+                            wlock.push(stream);
+                            log::debug!(
+                                "Added stream for topic {} to subscriber {}",
+                                connection_header.topic,
+                                peer_addr
+                            );
                         } else {
                             let header_str = connection_header[..bytes]
                                 .into_iter()


### PR DESCRIPTION
## Description
Prior to this change running `rostopic hz` with any ros1 native publisher would result in no messages being received. This was due to "*" being sent as the md5sum for the topic (which appears undocumented). I suspect this was the behavior for all generic subscriptions (at least with rospy). With this change in place `rostopic hz` now works.

## Fixes

## Checklist
- [x] Update CHANGELOG.md

