### PR TITLE
Fix Service Servers Shutdown Cleanly

### DIFF
--- a/docker/noetic_compose.yaml
+++ b/docker/noetic_compose.yaml
@@ -1,6 +1,8 @@
 services:
   rosbridge:
     image: carter12s/roslibrust-ci-noetic:rust-1-72
+    # network_mode host required for ros1 testing
+    network_mode: host
     ports:
       - "9090:9090"
       # Pass through the ros master port for native ros1 testing

--- a/roslibrust/src/ros1/node/handle.rs
+++ b/roslibrust/src/ros1/node/handle.rs
@@ -1,10 +1,7 @@
 use super::actor::{Node, NodeServerHandle};
-use crate::{
-    ros1::{
-        names::Name, publisher::Publisher, service_client::ServiceClient, subscriber::Subscriber,
-        NodeError, ServiceServer,
-    },
-    RosLibRustResult,
+use crate::ros1::{
+    names::Name, publisher::Publisher, service_client::ServiceClient, subscriber::Subscriber,
+    NodeError, ServiceServer,
 };
 
 /// Represents a handle to an underlying [Node]. NodeHandle's can be freely cloned, moved, copied, etc.
@@ -90,7 +87,7 @@ impl NodeHandle {
             .inner
             .register_service_client::<T>(&service_name)
             .await?;
-        Ok(ServiceClient::new(&service_name, sender))
+        Ok(sender)
     }
 
     pub async fn advertise_service<T, F>(
@@ -125,13 +122,11 @@ impl NodeHandle {
         let copy = self.clone();
         let name_copy = service_name.to_string();
         tokio::spawn(async move {
-          let result = copy.inner.unadvertise_service(&name_copy).await;
-          if let Err(e) = result{
-            log::error!("Failed to undvertise service: {e:?}");
-          }
+            let result = copy.inner.unadvertise_service(&name_copy).await;
+            if let Err(e) = result {
+                log::error!("Failed to undvertise service: {e:?}");
+            }
         });
         Ok(())
     }
-
-    pub(crate) fn unadvertise_service_client(&self, )
 }

--- a/roslibrust/src/ros1/publisher.rs
+++ b/roslibrust/src/ros1/publisher.rs
@@ -1,7 +1,4 @@
-use crate::{
-    ros1::{names::Name, tcpros::ConnectionHeader},
-    RosLibRustError,
-};
+use crate::ros1::{names::Name, tcpros::ConnectionHeader};
 use abort_on_drop::ChildTask;
 use roslibrust_codegen::RosMessageType;
 use std::{

--- a/roslibrust/src/ros1/service_server.rs
+++ b/roslibrust/src/ros1/service_server.rs
@@ -42,11 +42,10 @@ impl ServiceServer {
 
 impl Drop for ServiceServer {
     fn drop(&mut self) {
-        // MAJOR TODO
-        // unimplemented!()
-        // Need to eventually define and call this:
-        // self.node_handle
-        //     .unadvertise_service(&self.service_name.to_string());
+        debug!("Dropping service server: {:?}", self.service_name);
+        let _ = self
+            .node_handle
+            .unadvertise_service_server(&self.service_name.to_string());
     }
 }
 
@@ -56,6 +55,13 @@ pub(crate) struct ServiceServerLink {
     // Task is automatically aborted when link is dropped
     _child_task: ChildTask<()>,
     port: u16,
+    service_name: String,
+}
+
+impl Drop for ServiceServerLink {
+    fn drop(&mut self) {
+        log::debug!("Dropping service server link: {:?}", self.service_name);
+    }
 }
 
 impl ServiceServerLink {
@@ -75,12 +81,14 @@ impl ServiceServerLink {
             .local_addr()
             .expect("Bound tcp address did not have local address")
             .port();
+        let service_name_copy = service_name.to_string();
 
         let task = tokio::spawn(Self::actor(tcp_listener, service_name, node_name, method));
 
         Ok(Self {
             _child_task: task.into(),
             port,
+            service_name: service_name_copy,
         })
     }
 
@@ -102,17 +110,21 @@ impl ServiceServerLink {
         // can access it in parrallel and not worry about the lifetime.
         // TODO: it may be better to Arc it upfront?
         let arc_method = Arc::new(method);
+        // Tasks list here is needed to ensure that dropping this future drops child futures
+        let mut tasks: Vec<ChildTask<()>> = vec![];
         loop {
             // Accept new TCP connections
             match listener.accept().await {
                 Ok((stream, peer_addr)) => {
-                    tokio::spawn(Self::handle_tcp_connection(
+                    let task = tokio::spawn(Self::handle_tcp_connection(
                         stream,
                         peer_addr,
                         service_name.clone(),
                         node_name.clone(),
                         arc_method.clone(),
                     ));
+                    // Add spawned task to child task list to ensure dropping shuts down server
+                    tasks.push(task.into());
                 }
                 Err(e) => {
                     // Not entirely sure what circumstances can cause this?
@@ -287,5 +299,65 @@ mod test {
 
         assert_eq!(call.sum, 3);
         debug!("Got 3");
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn dropping_service_server_kill_correctly() {
+        debug!("Getting node handle");
+        let nh = NodeHandle::new("http://localhost:11311", "dropping_service_node")
+            .await
+            .unwrap();
+
+        let server_fn = |request: test_msgs::AddTwoIntsRequest| {
+            info!("Got request: {request:?}");
+            return Ok(test_msgs::AddTwoIntsResponse {
+                sum: request.a + request.b,
+            });
+        };
+
+        // Create the server
+        let handle = nh
+            .advertise_service::<test_msgs::AddTwoInts, _>("~/add_two", server_fn)
+            .await
+            .unwrap();
+
+        // Make the request (should succeed)
+        let client = nh
+            .service_client::<test_msgs::AddTwoInts>("~/add_two")
+            .await
+            .unwrap();
+        let _call: test_msgs::AddTwoIntsResponse = client
+            .call(&test_msgs::AddTwoIntsRequest { a: 1, b: 2 })
+            .await
+            .unwrap();
+
+        // Shut down the server
+        std::mem::drop(handle);
+        // Wait for shut down to process
+        tokio::time::sleep(tokio::time::Duration::from_millis(250)).await;
+
+        // Make the request again (should fail)
+        let call_2 = client
+            .call(&test_msgs::AddTwoIntsRequest { a: 1, b: 2 })
+            .await;
+        debug!("Got call_2: {call_2:?}");
+        assert!(
+            call_2.is_err(),
+            "Shouldn't be able to call after server is shut down"
+        );
+
+        // Drop our client (should expunge the storage of the client from the NodeServer)
+        std::mem::drop(client);
+        let client = nh
+            .service_client::<test_msgs::AddTwoInts>("~/add_two")
+            .await;
+
+        // Client should fail to create as there should be no provider of the service
+        assert!(
+            client.is_err(),
+            "Shouldn't be able to connect again (no provider of service)"
+        );
+
+        // TODO as an extra test here we could make a rosapi call
     }
 }

--- a/roslibrust/src/ros1/tcpros.rs
+++ b/roslibrust/src/ros1/tcpros.rs
@@ -192,7 +192,7 @@ pub async fn establish_connection(
 
     let mut responded_header_bytes = Vec::with_capacity(header_len);
     let bytes = stream.read_buf(&mut responded_header_bytes).await?;
-    if let Ok(responded_header) = ConnectionHeader::from_bytes(&responded_header_bytes[..bytes]) {
+    if let Ok(_responded_header) = ConnectionHeader::from_bytes(&responded_header_bytes[..bytes]) {
         // TODO we should really examine this md5sum logic...
         // according to the ROS documentation, the service isn't required to respond
         // with anything other than caller_id

--- a/roslibrust/src/rosbridge/client.rs
+++ b/roslibrust/src/rosbridge/client.rs
@@ -130,7 +130,6 @@ impl ClientHandle {
             .or_insert(Subscription {
                 handles: HashMap::new(),
                 topic_type: Msg::ROS_TYPE_NAME.to_string(),
-                known_publishers: vec![],
             });
 
         // TODO Possible bug here? We send a subscribe message each time even if already subscribed

--- a/roslibrust/src/rosbridge/mod.rs
+++ b/roslibrust/src/rosbridge/mod.rs
@@ -103,11 +103,6 @@ pub(crate) struct Subscription {
     pub(crate) handles: HashMap<uuid::Uuid, Callback>,
     /// Name of ros type (package_name/message_name), used for re-subscribes
     pub(crate) topic_type: String,
-
-    // TODO consider specializing this type for ros1_native
-    // Will contain the list of publishers of this topic as told to us by rosmaster
-    // Currently only used / populated with ros1 native
-    pub(crate) known_publishers: Vec<String>,
 }
 
 // TODO move out of rosbridge and into common


### PR DESCRIPTION
## Description
Add logic to both ServiceClient and ServiceServer to correctly clean-up after themselves when their respective handles are dropped.

## Fixes
Closes: #165 

## Checklist
- [ ] Update CHANGELOG.md

