### PR TITLE
Fix a lot of header shenanigans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- Bug with ros1 native publishers not parsing connection headers correctly
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1276,7 +1276,7 @@ dependencies = [
 
 [[package]]
 name = "roslibrust"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "abort-on-drop",
  "anyhow",
@@ -1313,7 +1313,7 @@ dependencies = [
 
 [[package]]
 name = "roslibrust_codegen"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "env_logger 0.10.0",
  "lazy_static",
@@ -1335,7 +1335,7 @@ dependencies = [
 
 [[package]]
 name = "roslibrust_codegen_macro"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/roslibrust_genmsg/Cargo.toml
+++ b/roslibrust_genmsg/Cargo.toml
@@ -24,7 +24,7 @@ itertools = "0.12"
 lazy_static = "1.4"
 log = "0.4"
 minijinja = "2.0"
-roslibrust_codegen = { path = "../roslibrust_codegen", version = "0.9.0" }
+roslibrust_codegen = { path = "../roslibrust_codegen", version = "0.10.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 


### PR DESCRIPTION
## Description
Create a common function for receiving a ros1 native connection header, and use it across the 4 receivers (publisher, subscriber, service_client, service_server). Fixes bug where publisher was trying to parse connection header with the overall header length still at the front.

## Fixes
Closes: #171 

## Checklist
- [ ] Update CHANGELOG.md

