### PR TITLE
Fix 178 subscriber buffer size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Bug with message_definitions provided by Publisher in the connection header not being the fully expanded definition.
+- Bug with ROS1 native subscribers not being able to receive messages larger than 4096 bytes.
 
 ### Changed
 

--- a/roslibrust/src/ros1/publisher.rs
+++ b/roslibrust/src/ros1/publisher.rs
@@ -97,7 +97,7 @@ impl Publication {
                     );
 
                     // Read the connection header:
-                    let connection_header = match tcpros::recieve_header(&mut stream).await {
+                    let connection_header = match tcpros::receive_header(&mut stream).await {
                         Ok(header) => header,
                         Err(e) => {
                             log::error!("Failed to read connection header: {e:?}");


### PR DESCRIPTION
## Description
- Fixed bug where subscribers weren't handling message size correctly
- Standardized logic for receiving a ROS1 message body that was duplicated in subscriber, service_client and service_server
- Added a unit test for subscribers for large payload

## Fixes
Closes: #178 

## Checklist
- [x] Update CHANGELOG.md

