### PR TITLE
Use type aliases to clean-up a lot of function definitions

### DIFF
--- a/roslibrust/src/lib.rs
+++ b/roslibrust/src/lib.rs
@@ -100,6 +100,7 @@
 
 mod rosbridge;
 pub use rosbridge::*;
+use roslibrust_codegen::RosServiceType;
 
 #[cfg(feature = "rosapi")]
 pub mod rosapi;
@@ -139,3 +140,26 @@ pub enum RosLibRustError {
 /// Note: many functions which currently return this will be updated to provide specific error
 /// types in the future instead of the generic error here.
 pub type RosLibRustResult<T> = Result<T, RosLibRustError>;
+
+// Note: service Fn is currently defined here as it used by ros1 and roslibrust impls
+/// This trait describes a function which can validly act as a ROS service
+/// server with roslibrust. We're really just using this as a trait alias
+/// as the full definition is overly verbose and trait aliases are unstable.
+pub trait ServiceFn<T: RosServiceType>:
+    Fn(T::Request) -> Result<T::Response, Box<dyn std::error::Error + 'static + Send + Sync>>
+    + Send
+    + Sync
+    + 'static
+{
+}
+
+/// Automatic implementation of ServiceFn for Fn
+impl<T, F> ServiceFn<T> for F
+where
+    T: RosServiceType,
+    F: Fn(T::Request) -> Result<T::Response, Box<dyn std::error::Error + 'static + Send + Sync>>
+        + Send
+        + Sync
+        + 'static,
+{
+}

--- a/roslibrust/src/ros1/mod.rs
+++ b/roslibrust/src/ros1/mod.rs
@@ -19,3 +19,10 @@ pub use subscriber::Subscriber;
 mod service_server;
 pub use service_server::ServiceServer;
 mod tcpros;
+
+/// Provides a common type alias for type erased service server functions.
+/// Internally we use this type to store collections of server functions.
+pub(crate) type TypeErasedCallback = dyn Fn(Vec<u8>) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>>
+    + Send
+    + Sync
+    + 'static;

--- a/roslibrust/src/ros1/node/actor.rs
+++ b/roslibrust/src/ros1/node/actor.rs
@@ -6,9 +6,9 @@ use crate::{
         service_client::ServiceClientLink,
         service_server::ServiceServerLink,
         subscriber::Subscription,
-        MasterClient, NodeError, ProtocolParams, ServiceClient,
+        MasterClient, NodeError, ProtocolParams, ServiceClient, TypeErasedCallback,
     },
-    RosLibRustError,
+    RosLibRustError, ServiceFn,
 };
 use abort_on_drop::ChildTask;
 use log::warn;
@@ -69,11 +69,7 @@ pub enum NodeMsg {
         service: Name,
         service_type: String,
         srv_definition: String,
-        server: Box<
-            dyn Fn(Vec<u8>) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>>
-                + Send
-                + Sync,
-        >,
+        server: Box<TypeErasedCallback>,
         md5sum: String,
     },
     UnregisterServiceServer {
@@ -216,10 +212,7 @@ impl NodeServerHandle {
     ) -> Result<(), NodeError>
     where
         T: RosServiceType,
-        F: Fn(T::Request) -> Result<T::Response, Box<dyn std::error::Error + Send + Sync>>
-            + Send
-            + Sync
-            + 'static,
+        F: ServiceFn<T>,
     {
         let (sender, receiver) = oneshot::channel();
 
@@ -698,11 +691,7 @@ impl Node {
         service: &Name,
         service_type: &str,
         srv_definition: &str,
-        server: Box<
-            dyn Fn(Vec<u8>) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>>
-                + Send
-                + Sync,
-        >,
+        server: Box<TypeErasedCallback>,
         md5sum: &str,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let found = self.service_servers.get_mut(service_type);

--- a/roslibrust/src/ros1/node/handle.rs
+++ b/roslibrust/src/ros1/node/handle.rs
@@ -1,7 +1,10 @@
 use super::actor::{Node, NodeServerHandle};
-use crate::ros1::{
-    names::Name, publisher::Publisher, service_client::ServiceClient, subscriber::Subscriber,
-    NodeError, ServiceServer,
+use crate::{
+    ros1::{
+        names::Name, publisher::Publisher, service_client::ServiceClient, subscriber::Subscriber,
+        NodeError, ServiceServer,
+    },
+    ServiceFn,
 };
 
 /// Represents a handle to an underlying [Node]. NodeHandle's can be freely cloned, moved, copied, etc.
@@ -103,10 +106,7 @@ impl NodeHandle {
     ) -> Result<ServiceServer, NodeError>
     where
         T: roslibrust_codegen::RosServiceType,
-        F: Fn(T::Request) -> Result<T::Response, Box<dyn std::error::Error + Send + Sync>>
-            + Send
-            + Sync
-            + 'static,
+        F: ServiceFn<T>,
     {
         let service_name = Name::new(service_name)?;
         let _response = self

--- a/roslibrust/src/ros1/service_server.rs
+++ b/roslibrust/src/ros1/service_server.rs
@@ -9,17 +9,7 @@ use tokio::io::AsyncWriteExt;
 
 use crate::ros1::tcpros::{self, ConnectionHeader};
 
-use super::{names::Name, NodeHandle};
-
-// TODO: someday I'd like to define a trait alias here for a ServerFunction
-// Currently unstable:
-// https://doc.rust-lang.org/beta/unstable-book/language-features/trait-alias.html
-// trait ServerFunction<T> = Fn(T::Request) -> Err(T::Response, Box<dyn std::error::Error + Send + Sync>) + Send + Sync + 'static;
-
-type TypeErasedCallback = dyn Fn(Vec<u8>) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>>
-    + Send
-    + Sync
-    + 'static;
+use super::{names::Name, NodeHandle, TypeErasedCallback};
 
 /// ServiceServer is simply a lifetime control
 /// The underlying ServiceServer is kept alive while object is kept alive.

--- a/roslibrust/src/rosbridge/client.rs
+++ b/roslibrust/src/rosbridge/client.rs
@@ -1,6 +1,6 @@
 use crate::{
     rosbridge::comm::{self, RosBridgeComm},
-    Publisher, RosLibRustError, RosLibRustResult, ServiceHandle, Subscriber,
+    Publisher, RosLibRustError, RosLibRustResult, ServiceFn, ServiceHandle, Subscriber,
 };
 use anyhow::anyhow;
 use dashmap::DashMap;
@@ -427,13 +427,7 @@ impl ClientHandle {
     ) -> RosLibRustResult<ServiceHandle>
     where
         T: RosServiceType,
-        F: Fn(
-                T::Request,
-            )
-                -> Result<T::Response, Box<dyn std::error::Error + 'static + Send + Sync>>
-            + Send
-            + Sync
-            + 'static,
+        F: ServiceFn<T>,
     {
         self.check_for_disconnect()?;
         {


### PR DESCRIPTION
## Description
`Insert description`

## Fixes
Closes: `number`

## Checklist
- [ ] Update CHANGELOG.md

