### PR TITLE
subscribe to any topic of any type and get received messages as a raw vector of bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ROS1 Native Publishers now support latching behavior
 - The XML RPC client for interacting directly with the rosmaster server has been exposed as a public API
 - Experimental: Initial support for writing generic clients that can be compile time specialized for rosbridge or ros1
+- Can subscribe to any topic and get raw bytes instead of a deserialized message of known type
 
 ### Fixed
 

--- a/roslibrust/src/ros1/node/handle.rs
+++ b/roslibrust/src/ros1/node/handle.rs
@@ -83,7 +83,7 @@ impl NodeHandle {
     ) -> Result<SubscriberAny, NodeError> {
         let receiver = self
             .inner
-            .register_subscriber::<Vec<u8>>(topic_name, queue_size)
+            .register_subscriber::<roslibrust_codegen::ShapeShifter>(topic_name, queue_size)
             .await?;
         Ok(SubscriberAny::new(receiver))
     }

--- a/roslibrust/src/ros1/node/handle.rs
+++ b/roslibrust/src/ros1/node/handle.rs
@@ -2,8 +2,7 @@ use super::actor::{Node, NodeServerHandle};
 use crate::{
     ros1::{
         names::Name, publisher::Publisher, service_client::ServiceClient, subscriber::Subscriber,
-        subscriber::SubscriberAny,
-        NodeError, ServiceServer,
+        subscriber::SubscriberAny, NodeError, ServiceServer,
     },
     ServiceFn,
 };

--- a/roslibrust/src/ros1/node/handle.rs
+++ b/roslibrust/src/ros1/node/handle.rs
@@ -2,6 +2,7 @@ use super::actor::{Node, NodeServerHandle};
 use crate::{
     ros1::{
         names::Name, publisher::Publisher, service_client::ServiceClient, subscriber::Subscriber,
+        subscriber::SubscriberAny,
         NodeError, ServiceServer,
     },
     ServiceFn,
@@ -73,6 +74,18 @@ impl NodeHandle {
             .register_publisher::<T>(topic_name, queue_size, latching)
             .await?;
         Ok(Publisher::new(topic_name, sender))
+    }
+
+    pub async fn subscribe_any(
+        &self,
+        topic_name: &str,
+        queue_size: usize,
+    ) -> Result<SubscriberAny, NodeError> {
+        let receiver = self
+            .inner
+            .register_subscriber::<Vec<u8>>(topic_name, queue_size)
+            .await?;
+        Ok(SubscriberAny::new(receiver))
     }
 
     pub async fn subscribe<T: roslibrust_codegen::RosMessageType>(

--- a/roslibrust/src/ros1/subscriber.rs
+++ b/roslibrust/src/ros1/subscriber.rs
@@ -1,6 +1,6 @@
 use crate::ros1::{names::Name, tcpros::ConnectionHeader};
 use abort_on_drop::ChildTask;
-use roslibrust_codegen::RosMessageType;
+use roslibrust_codegen::{RosMessageType, ShapeShifter};
 use std::{marker::PhantomData, sync::Arc};
 use tokio::{
     io::AsyncWriteExt,
@@ -41,7 +41,7 @@ impl<T: RosMessageType> Subscriber<T> {
 
 pub struct SubscriberAny {
     receiver: broadcast::Receiver<Vec<u8>>,
-    _phantom: PhantomData<Vec<u8>>,
+    _phantom: PhantomData<ShapeShifter>,
 }
 
 impl SubscriberAny {
@@ -52,6 +52,7 @@ impl SubscriberAny {
         }
     }
 
+    // pub async fn next(&mut self) -> Option<Result<ShapeShifter, SubscriberError>> {
     pub async fn next(&mut self) -> Option<Result<Vec<u8>, SubscriberError>> {
         let data = match self.receiver.recv().await {
             Ok(v) => v,

--- a/roslibrust/src/ros1/subscriber.rs
+++ b/roslibrust/src/ros1/subscriber.rs
@@ -178,7 +178,9 @@ async fn establish_publisher_connection(
     stream.write_all(&conn_header_bytes[..]).await?;
 
     if let Ok(responded_header) = tcpros::receive_header(&mut stream).await {
-        if conn_header.md5sum == Some("*".to_string()) || conn_header.md5sum == responded_header.md5sum {
+        if conn_header.md5sum == Some("*".to_string())
+            || conn_header.md5sum == responded_header.md5sum
+        {
             log::debug!(
                 "Established connection with publisher for {:?}",
                 conn_header.topic

--- a/roslibrust/tests/ros1_native_integration_tests.rs
+++ b/roslibrust/tests/ros1_native_integration_tests.rs
@@ -24,10 +24,7 @@ mod tests {
             .await
             .unwrap();
 
-        let mut subscriber = nh
-            .subscribe_any("/test_subscribe_any", 1)
-            .await
-            .unwrap();
+        let mut subscriber = nh.subscribe_any("/test_subscribe_any", 1).await.unwrap();
 
         publisher
             .publish(&std_msgs::String {

--- a/roslibrust_codegen/src/integral_types.rs
+++ b/roslibrust_codegen/src/integral_types.rs
@@ -36,6 +36,13 @@ impl RosMessageType for Time {
     const DEFINITION: &'static str = "";
 }
 
+// The equivalent of rospy AnyMsg or C++ ShapeShifter, subscribe_any() uses this type
+impl RosMessageType for Vec<u8> {
+    const ROS_TYPE_NAME: &'static str = "*";
+    const MD5SUM: &'static str = "*";
+    const DEFINITION: &'static str = "";
+}
+
 // TODO provide chrono conversions here behind a cfg flag
 
 /// Matches the integral ros1 duration type, with extensions for ease of use

--- a/roslibrust_codegen/src/integral_types.rs
+++ b/roslibrust_codegen/src/integral_types.rs
@@ -36,8 +36,11 @@ impl RosMessageType for Time {
     const DEFINITION: &'static str = "";
 }
 
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Debug, Default, Clone, PartialEq)]
+pub struct ShapeShifter(Vec<u8>);
+
 // The equivalent of rospy AnyMsg or C++ ShapeShifter, subscribe_any() uses this type
-impl RosMessageType for Vec<u8> {
+impl RosMessageType for ShapeShifter {
     const ROS_TYPE_NAME: &'static str = "*";
     const MD5SUM: &'static str = "*";
     const DEFINITION: &'static str = "";


### PR DESCRIPTION
## Description

Subscribe to a topic without needing to know the type, and then get the received message as a raw vector of bytes, similar to rospy AnyMsg and roscpp ShapeShifter.

This isn't quite what was suggested in https://github.com/Carter12s/roslibrust/issues/190#issuecomment-2276521772-  I couldn't figure out how to make a function within the existing Subscriber that can do different things depending on type, it needs specialization?  Is having both a Subscriber and SubscriberAny bad for other parts of roslibrust?

## Fixes
Closes: #190

## Checklist
- [ :heavy_check_mark: ] Update CHANGELOG.md

