### PR TITLE
Change to using write_all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - ROS1 Native Publishers correctly call unadvertise when dropped
+- ROS1 Native Publishers no longer occasionally truncate very large messages (>5MB)
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1022,16 +1022,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
-name = "parking_lot"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
 name = "parking_lot_core"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1781,7 +1771,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1022,6 +1022,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "parking_lot_core"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1314,8 +1324,10 @@ dependencies = [
  "diffy",
  "env_logger 0.10.2",
  "lazy_static",
+ "log",
  "roslibrust",
  "roslibrust_codegen",
+ "tokio",
 ]
 
 [[package]]
@@ -1769,6 +1781,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/roslibrust/src/ros1/tcpros.rs
+++ b/roslibrust/src/ros1/tcpros.rs
@@ -257,7 +257,7 @@ pub async fn receive_body(stream: &mut TcpStream) -> Result<Vec<u8>, std::io::Er
     let mut body = vec![0u8; body_len as usize + 4];
     // Copy the length into the first four bytes
     body[..4].copy_from_slice(&body_len.to_le_bytes());
-    // Read the body into the buffer
+    // Read the body into the buffer after the header
     stream.read_exact(&mut body[4..]).await?;
 
     // Return body

--- a/roslibrust_test/Cargo.toml
+++ b/roslibrust_test/Cargo.toml
@@ -5,9 +5,15 @@ edition = "2021"
 
 [dependencies]
 env_logger = "0.10"
-roslibrust = { path = "../roslibrust" }
+roslibrust = { path = "../roslibrust", features = ["ros1"] }
 roslibrust_codegen = { path = "../roslibrust_codegen" }
 lazy_static = "1.4"
+tokio = { version = "1.20", features = ["full"] }
+log = "0.4"
 
 [dev-dependencies]
 diffy = "0.3.0"
+
+[[bin]]
+path = "src/performance_ramp.rs"
+name = "ramp"

--- a/roslibrust_test/Cargo.toml
+++ b/roslibrust_test/Cargo.toml
@@ -8,7 +8,7 @@ env_logger = "0.10"
 roslibrust = { path = "../roslibrust", features = ["ros1"] }
 roslibrust_codegen = { path = "../roslibrust_codegen" }
 lazy_static = "1.4"
-tokio = { version = "1.20", features = ["full"] }
+tokio = { version = "1.20", features = ["net", "sync"] }
 log = "0.4"
 
 [dev-dependencies]

--- a/roslibrust_test/src/performance_ramp.rs
+++ b/roslibrust_test/src/performance_ramp.rs
@@ -1,0 +1,76 @@
+//! Goal of this executable is to asses the bandwidths and performance limits of roslibrust.
+//! This may turn into a benchmark later.
+
+use log::*;
+mod ros1;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::builder()
+        .parse_env(env_logger::Env::default().default_filter_or("info"))
+        .format_timestamp_millis()
+        .init();
+    // Goal is to send a large image payload at progressively higher rates until we sta`t to lag
+    // Requires running roscore
+    let client =
+        roslibrust::ros1::NodeHandle::new("http://localhost:11311", "performance_ramp").await?;
+
+    let publisher = client
+        .advertise::<ros1::sensor_msgs::Image>("/image_topic", 1, false)
+        .await?;
+    let mut subscriber = client
+        .subscribe::<ros1::sensor_msgs::Image>("/image_topic", 1)
+        .await?;
+    // Startup delay to make sure pub and sub are connected
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    // Publisher task
+    tokio::spawn(async move {
+        for data_size_mb in (10..=100).step_by(10) {
+            // Creating a big vector here
+            let mut data = vec![0; data_size_mb * 1_000_000];
+            *data.last_mut().unwrap() = 69;
+            let image = ros1::sensor_msgs::Image {
+                header: ros1::std_msgs::Header {
+                    stamp: roslibrust_codegen::Time { secs: 0, nsecs: 0 },
+                    frame_id: "test".to_string(),
+                    seq: data_size_mb as u32,
+                },
+                height: 1080,
+                width: 1920,
+                encoding: "bgr8".to_string(),
+                is_bigendian: false as u8,
+                step: 5760,
+                data,
+            };
+            publisher.publish(&image).await.unwrap();
+            // Send at 10Hz
+            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        }
+        info!("Test complete");
+        // Final bonus sleep to make sure last message sends before shutting down
+        tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+        std::process::exit(0);
+    });
+
+    // Subscriber task
+    loop {
+        if let Some(msg) = subscriber.next().await {
+            match msg {
+                Ok(msg) => {
+                    info!("Got message @ {:?}", msg.header.seq);
+                }
+                Err(e) => {
+                    error!("Error: {e}");
+                    break;
+                }
+            }
+        } else {
+            // Shutting down
+            error!("Channel dropped?");
+            break;
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Description
Discovered some bugs in production related to very large messages. Turnout out our usage of write() vs. write_all() on the publisher side was incorrect and would truncate large messages (had to be several MB before I actually saw this occur). With this change messages would send reliably with no upper limit I could find (probably u32 size at this point).

## Fixes
Closes: NAN

## Checklist
- [ ] Update CHANGELOG.md

